### PR TITLE
Updated how internal libraries are located

### DIFF
--- a/libraries/azure_rg.rb
+++ b/libraries/azure_rg.rb
@@ -1,5 +1,5 @@
 
-require_relative 'common/helpers'
+require File.expand_path(File.dirname(__FILE__) + '/common/helpers')
 
 # Class to test the resources in Resource Groups
 #

--- a/libraries/azure_vm.rb
+++ b/libraries/azure_vm.rb
@@ -1,5 +1,5 @@
 
-require_relative 'common/helpers'
+require File.expand_path(File.dirname(__FILE__) + '/common/helpers')
 
 # Class to retrieve information about the specified virtual machine
 #

--- a/libraries/azure_vm_datadisks.rb
+++ b/libraries/azure_vm_datadisks.rb
@@ -1,5 +1,5 @@
 
-require_relative 'common/helpers'
+require File.expand_path(File.dirname(__FILE__) + '/common/helpers')
 require 'uri'
 
 # Class to test the data disks that are attached to the specified VM

--- a/libraries/common/helpers.rb
+++ b/libraries/common/helpers.rb
@@ -1,9 +1,9 @@
 
-require_relative '../azure_conn'
+require File.expand_path(File.dirname(__FILE__) + '/../azure_conn')
 
-require_relative 'resource_management'
-require_relative 'compute_management'
-require_relative 'network_management'
+require File.expand_path(File.dirname(__FILE__) + '/resource_management')
+require File.expand_path(File.dirname(__FILE__) + '/compute_management')
+require File.expand_path(File.dirname(__FILE__) + '/network_management')
 
 # Helper class to configure and give access to the various management components of Azure
 # Also provides shortcuts for certain components, such as returing the VM object and performing


### PR DESCRIPTION
Does not use `require_relatove` as meant files were loaded from the project directory and NOT the resource pack.

Closes #11

Signed-off-by: Russell Seymour <russell.seymour@turtlesystems.co.uk>