### PR TITLE
Adds ability to opt in to use a Network Watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ rake azure:login
 rake tf:apply
 ```
 
+Creating a new environment with a Network Watcher:
+```
+rake azure:login
+rake network_watcher tf:apply
+```
+You may only have a single Network Watcher per a subscription. Use this carefully if you are working with other team members.
+
 Updating a running environment (e.g. when you change the .tf file):
 ```
 rake azure:login
@@ -94,6 +101,12 @@ To run integration tests:
 ```
 bundle
 rake test:integration
+```
+
+To run integration tests including a Network Watcher:
+```
+bundle
+rake network_watcher test:integration
 ```
 
 To run a control called `azurerm_virtual_machine`:

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,7 @@ desc 'Set up Azure env, run integration tests, destroy Azure env'
 task azure: 'azure:run'
 
 namespace :azure do
-  task run: ['tf:apply', 'test:integration', 'tf:destroy']
+  task run: ['network_watcher', 'tf:apply', 'test:integration', 'tf:destroy']
 
   desc 'Authenticate with the Azure CLI'
   task :login do
@@ -81,6 +81,12 @@ namespace :inspec do
 
     status.exitstatus
   end
+end
+
+desc 'This will enable network watcher creation and integration tests'
+task :network_watcher do
+  ENV['ENABLE_NETWORK_WATCHER'] = 'true'
+  ENV['TF_VAR_network_watcher_enabled'] = '1'
 end
 
 task :setup_env do

--- a/terraform/azure.tf
+++ b/terraform/azure.tf
@@ -34,6 +34,7 @@ resource "azurerm_resource_group" "rg" {
 
 resource "azurerm_network_watcher" "rg" {
   name                = "${azurerm_resource_group.rg.name}-netwatcher"
+  count               = "${var.network_watcher_enabled}"
   location            = "${azurerm_resource_group.rg.location}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   tags {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,11 +3,11 @@ output "resource_group" {
 }
 
 output "network_watcher_name" {
-  value = "${azurerm_network_watcher.rg.name}"
+  value = "${azurerm_network_watcher.rg.*.name}"
 }
 
 output "network_watcher_id" {
-  value = "${azurerm_network_watcher.rg.id}"
+  value = "${azurerm_network_watcher.rg.*.id}"
 }
 
 output "location" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,3 +49,7 @@ variable "encrypted_disk_name" {
 variable "unmanaged_data_disk_name" {
   default = "linux-internal-datadisk-1"
 }
+
+variable "network_watcher_enabled" {
+  default = false
+}

--- a/test/integration/verify/controls/azure_network_watcher.rb
+++ b/test/integration/verify/controls/azure_network_watcher.rb
@@ -1,8 +1,10 @@
 resource_group = attribute('resource_group',       default: nil)
-nw             = attribute('network_watcher_name', default: nil)
-nw_id          = attribute('network_watcher_id',   default: nil)
+nw             = attribute('network_watcher_name', default: nil).first
+nw_id          = attribute('network_watcher_id',   default: nil).first
 
 control 'azure_network_watcher' do
+  only_if { ENV['ENABLE_NETWORK_WATCHER'] }
+
   describe azure_network_watcher(resource_group: resource_group, name: nw) do
     it                        { should exist }
     its('id')                 { should eq nw_id }

--- a/test/integration/verify/controls/azure_network_watchers.rb
+++ b/test/integration/verify/controls/azure_network_watchers.rb
@@ -1,6 +1,8 @@
 resource_group = attribute('resource_group', default: nil)
 
 control 'azure_network_watchers' do
+  only_if { ENV['ENABLE_NETWORK_WATCHER'] }
+
   describe azure_network_watchers(resource_group: resource_group) do
     it           { should exist }
     its('names') { should be_an(Array) }


### PR DESCRIPTION
We are limited to a single Network Watcher per subscription. This change
introduces a rake task that will allow you to opt in to using a Network
Watcher. If someone else needs it you may also quickly destroy the
Network Watcher from your environment to free up the resource.

This will create a Network Watcher and execute the integration tests assuming there's a Network Watcher:
```
rake azure:login 
rake network_watcher tf:apply
rake network_watcher test:integration
```

This will destroy a Network Watcher if one exists and execute the integration tests skipping any tests that require a Network Watcher:
```
rake azure:login
rake tf:apply
rake test:integration
```
Fixes: #65 

Signed-off-by: David McCown <dmccown@chef.io>