### PR TITLE
Add Availability section in each doc

### DIFF
--- a/docs/resources/azurerm_ad_user.md.erb
+++ b/docs/resources/azurerm_ad_user.md.erb
@@ -1,0 +1,184 @@
+---
+title: About the azurerm_ad_user Resource
+platform: azure
+---
+
+# azurerm\_ad\_user
+
+Use the `azurerm_ad_user` InSpec audit resource to test properties of
+an Azure Active Directory user within a Tenant.
+
+<br />
+
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
+### Version
+
+This resource first became available in 1.1.0 of the inspec-azure resource pack.
+
+## Syntax
+
+The `user_id` must be given as a parameter.
+
+    describe azurerm_ad_user(user_id: 'someUserId') do
+      it { should exist }
+    end
+
+<br />
+
+## Examples
+
+If an Active Directory user account is referenced with a valid ID
+
+    describe azurerm_ad_user(user_id: 'someValidId')
+      it { should exist }
+    end
+
+If an Active Directory user account is referenced with an invalid ID
+
+    describe azurerm_ad_user(user_id: 'someInvalidId')
+      it { should_not exist }
+    end
+
+<br />
+
+## Parameters
+
+  - `user_id`
+
+## Parameter Examples
+
+  # user_id is a required parameter
+  describe azurerm_ad_user(user_id: 'someUserId') do
+    ...
+  end
+
+## Properties
+
+  - `object_id', `account_enabled', `city', `country', `department',
+    `displayName', `facsimile_telephone_number', `given_name', `job_title',
+    `mail', `mail_nickname', `mobile', `password_policies', `password_profile',
+    `postal_code', `state', `street_address', `surname', `telephone_number',
+    `usage_location', `user_principal_name', `user_type'
+
+### object_id
+
+The user's object ID.
+
+### account_enabled
+
+Whether the account is enabled.
+
+### city
+
+The user's city.
+
+### country
+
+The user's country.
+
+### department
+
+The user's department.
+
+### displayName
+
+The display name of the user.
+
+### facsimile_telephone_number
+
+The user's facsimile (fax) number.
+
+### given_name
+
+The given name for the user.
+
+### job_title
+
+The user's job title.
+
+### mail
+
+The primary email address of the user.
+
+### mail_nickname
+
+The mail alias for the user.
+
+### mobile
+
+The user's mobile (cell) phone number.
+
+### password_policies
+
+The password policies for the user.
+
+### password_profile
+
+The password profile for the user.
+
+### postal_code
+
+The user's postal (ZIP) code.
+
+### state
+
+The user's state.
+
+### street_address
+
+The user's street address.
+
+### surname
+
+The user's surname (family name or last name).
+
+### telephone_number
+
+The user's telephone number.
+
+### usage_location
+
+A two letter country code (ISO standard 3166). Required for users that will be
+assigned licenses due to legal requirement to check for availability of
+services in countries. Examples include: "US", "JP", and "GB".
+
+### user_principal_name
+
+The principal name of the user.
+
+### user_type
+
+A string value that can be used to classify user types in your directory, such as 'Member' and 'Guest'.
+
+
+## Matchers
+
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
+
+### exists
+
+    describe azurerm_ad_user(user_id: 'someUserId') do
+      it { should exist }
+    end
+
+## Azure Permissions
+
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_ad_users.md.erb
+++ b/docs/resources/azurerm_ad_users.md.erb
@@ -54,12 +54,12 @@ name. This is a string value.
 
 ## Properties
 
-* `azure_ids`
+* `object_ids`
 * `display_names`
 * `mails`
 * `user_types`
 
-### azure\_ids
+### object\_ids
 
 The azureIds property provides a list of all User's Azure IDs.
 

--- a/docs/resources/azurerm_ad_users.md.erb
+++ b/docs/resources/azurerm_ad_users.md.erb
@@ -10,6 +10,25 @@ some or all Azure Active Directory users within a Tenant.
 
 <br />
 
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
+### Version
+
+This resource first became available in 1.1.0 of the inspec-azure resource pack.
+
 ## Syntax
 
 An `azurerm_ad_users` resource block returns all Azure Active Directory user accounts for the

--- a/docs/resources/azurerm_monitor_activity_log_alert.md.erb
+++ b/docs/resources/azurerm_monitor_activity_log_alert.md.erb
@@ -10,6 +10,21 @@ of an Azure Monitor Activity Log Alert.
 
 <br />
 
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
 ## Syntax
 
 An `azurerm_monitor_activity_log_alert` resource block identifies an Activity Log Alert by
@@ -18,6 +33,7 @@ name and resource group.
     describe azurerm_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
       ...
     end
+
 <br />
 
 ## Examples
@@ -38,12 +54,13 @@ name and resource group.
 
 ## Parameters
 
-* `name`
-* `resource_group`
+  - `name`
+  - `resource_group`
 
 ## Parameter Examples
 
-The resource group as well as the Activty Log Alert name.
+The resource group as well as the Activty Log Alert
+    name.
 
     describe azurerm_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
       its('operations') { should include 'Microsoft.Authorization/policyAssignments/write' }
@@ -51,22 +68,25 @@ The resource group as well as the Activty Log Alert name.
 
 ## Properties
 
-* `operations`
+  - `operations`
 
 ### operations
 
-The operations collection can be checked for the presence or absence of a given operation string.
+The operations collection can be checked for the presence or absence of a given operation
+string.
 
     its('operations') { should include 'Microsoft.Authorization/policyAssignments/write' }
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
-The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
+The control will pass if the resource returns a result. Use `should_not` if you expect
+zero matches.
 
     # If we expect 'AlertName' to always exist
     describe azurerm_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
@@ -80,5 +100,6 @@ The control will pass if the resource returns a result. Use `should_not` if you 
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_monitor_activity_log_alerts.md.erb
+++ b/docs/resources/azurerm_monitor_activity_log_alerts.md.erb
@@ -5,18 +5,35 @@ platform: azure
 
 # azurerm\_monitor\_activity\_log\_alerts
 
-Use the `azurerm_monitor_activity_log_alerts` InSpec audit resource to verify that an Activity Log
-Alert exists.
+Use the `azurerm_monitor_activity_log_alerts` InSpec audit resource to verify that an
+Activity Log Alert exists.
 
 <br />
 
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
 ## Syntax
 
-An `azurerm_monitor_activity_log_alerts` resource block identifies Activity Log Alerts by name.
+An `azurerm_monitor_activity_log_alerts` resource block identifies Activity Log Alerts by
+name.
 
     describe azurerm_monitor_activity_log_alerts do
       ...
     end
+
 <br />
 
 ## Examples
@@ -31,7 +48,7 @@ An `azurerm_monitor_activity_log_alerts` resource block identifies Activity Log 
 
 ## Properties
 
-* `names`
+  - `names`
 
 ### names
 
@@ -41,12 +58,14 @@ The name of the Activity Log Alert
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
-The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
+The control will pass if the resource returns a result. Use `should_not` if you expect
+zero matches.
 
     # If we expect 'ExampleLogAlert' to exist
     describe azurerm_monitor_activity_log_alerts do
@@ -60,5 +79,6 @@ The control will pass if the resource returns a result. Use `should_not` if you 
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_monitor_log_profile.md.erb
+++ b/docs/resources/azurerm_monitor_log_profile.md.erb
@@ -10,6 +10,21 @@ of an Azure Monitor Log Profile.
 
 <br />
 
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
 ## Syntax
 
 An `azurerm_monitor_log_profile` resource block identifies a Log Profile by name.
@@ -17,6 +32,7 @@ An `azurerm_monitor_log_profile` resource block identifies a Log Profile by name
     describe azurerm_monitor_log_profile(name: 'default') do
       ...
     end
+
 <br />
 
 ## Examples
@@ -37,7 +53,7 @@ An `azurerm_monitor_log_profile` resource block identifies a Log Profile by name
 
 ## Parameters
 
-* `name`
+  - `name`
 
 ## Parameter Examples
 
@@ -49,8 +65,8 @@ The name of the Log Profile.
 
 ## Properties
 
-* `retention_enabled`
-* `retention_days`
+  - `retention_enabled`
+  - `retention_days`
 
 ### retention\_enabled
 
@@ -66,12 +82,14 @@ Determine number of days retention is enabled for
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
-The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
+The control will pass if the resource returns a result. Use `should_not` if you expect
+zero matches.
 
     #  If we expect 'default' to exist
     describe azurerm_monitor_log_profile(name: 'default') do
@@ -85,5 +103,6 @@ The control will pass if the resource returns a result. Use `should_not` if you 
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_monitor_log_profiles.md.erb
+++ b/docs/resources/azurerm_monitor_log_profiles.md.erb
@@ -5,9 +5,25 @@ platform: azure
 
 # azurerm\_monitor\_log\_profiles
 
-Use the `azurerm_monitor_log_profiles` InSpec audit resource to verify that a Log Profile exists.
+Use the `azurerm_monitor_log_profiles` InSpec audit resource to verify that a Log Profile
+exists.
 
 <br />
+
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
 
 ## Syntax
 
@@ -16,6 +32,7 @@ An `azurerm_monitor_log_profiles` resource block identifies a Log Profile by nam
     describe azurerm_monitor_log_profiles do
       ...
     end
+
 <br />
 
 ## Examples
@@ -30,7 +47,7 @@ An `azurerm_monitor_log_profiles` resource block identifies a Log Profile by nam
 
 ## Properties
 
-* `names`
+  - `names`
 
 ### names
 
@@ -40,12 +57,14 @@ The name of the Log Profile
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
-The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
+The control will pass if the resource returns a result. Use `should_not` if you expect
+zero matches.
 
     # If we expect 'ExampleProfile' to exist
     describe azurerm_monitor_log_profiles do
@@ -59,5 +78,6 @@ The control will pass if the resource returns a result. Use `should_not` if you 
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_network_security_group.md.erb
+++ b/docs/resources/azurerm_network_security_group.md.erb
@@ -5,19 +5,36 @@ platform: azure
 
 # azurerm\_network\_security\_group
 
-Use the `azurerm_network_security_group` InSpec audit resource to test properties
-of an Azure Network Security Group.
+Use the `azurerm_network_security_group` InSpec audit resource to test properties of an
+Azure Network Security Group.
 
 <br />
+
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
 
 ## Syntax
 
 An `azurerm_network_security_group` resource block identifies a Network Security Group by
-name and Resource Group.
+name and Resource
+    Group.
 
     describe azurerm_network_security_group(resource_group: 'example', name: 'GroupName') do
       ...
     end
+
 <br />
 
 ## Examples
@@ -38,12 +55,13 @@ name and Resource Group.
 
 ## Parameters
 
-* `name`
-* `resource_group`
+  - `name`
+  - `resource_group`
 
 ## Parameter Examples
 
-The Resource Group as well as the Network Security Group name.
+The Resource Group as well as the Network Security Group
+    name.
 
     describe azurerm_network_security_group(resource_group: 'example', name: 'GroupName') do
       it { should allow_rdp_from_internet }
@@ -51,10 +69,10 @@ The Resource Group as well as the Network Security Group name.
 
 ## Properties
 
-* `security_rules`
-* `default_security_rules`
-* `allow_ssh_from_internet`
-* `allow_rdp_from_internet`
+  - `security_rules`
+  - `default_security_rules`
+  - `allow_ssh_from_internet`
+  - `allow_rdp_from_internet`
 
 ### security\_rules
 
@@ -84,18 +102,20 @@ the Security Rules and Default Security Rules for unrestricted RDP access.
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
-The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
+The control will pass if the resource returns a result. Use `should_not` if you expect
+zero matches.
 
     # If we expect 'GroupName' to always exist
     describe azurerm_network_security_group(resource_group: 'example', name: 'GroupName') do
       it { should exist }
     end
-
+    
     # If we expect 'EmptyGroupName' to never exist
     describe azurerm_network_security_group(resource_group: 'example', name: 'EmptyGroupName') do
       it { should_not exist }
@@ -103,5 +123,6 @@ The control will pass if the resource returns a result. Use `should_not` if you 
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_network_security_groups.md.erb
+++ b/docs/resources/azurerm_network_security_groups.md.erb
@@ -5,15 +5,30 @@ platform: azure
 
 # azurerm\_network\_security\_groups
 
-Use the `azurerm_network_security_groups` InSpec audit resource to enumerate
-Network Security Groups.
+Use the `azurerm_network_security_groups` InSpec audit resource to enumerate Network
+Security Groups.
 
 <br />
 
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
 ## Syntax
 
-An `azurerm_network_security_groups` resource block identifies Network Security
-Groups by Resource Group.
+An `azurerm_network_security_groups` resource block identifies Network Security Groups by
+Resource Group.
 
     describe azurerm_network_security_groups(resource_group: 'ExampleGroup') do
       ...
@@ -33,7 +48,7 @@ Groups by Resource Group.
 
 ## Properties
 
-* `names`
+  - `names`
 
 ### names
 
@@ -43,18 +58,20 @@ The name of the Network Security Group
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
-The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
+The control will pass if the resource returns a result. Use `should_not` if you expect
+zero matches.
 
     # If we expect 'ExampleGroup' Resource Group to have Network Security Groups
     describe azurerm_network_security_groups(resource_group: 'ExampleGroup') do
       it { should exist }
     end
-
+    
     # If we expect 'EmptyExampleGroup' Resource Group to not have Network Security Groups
     describe azurerm_network_security_groups(resource_group: 'EmptyExampleGroup') do
       it { should_not exist }
@@ -62,5 +79,6 @@ The control will pass if the resource returns a result. Use `should_not` if you 
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_network_watcher.md.erb
+++ b/docs/resources/azurerm_network_watcher.md.erb
@@ -5,19 +5,35 @@ platform: azure
 
 # azurerm\_network\_watcher
 
-Use the `azurerm_network_watcher` InSpec audit resource to test properties
-of an Azure Network Watcher.
+Use the `azurerm_network_watcher` InSpec audit resource to test properties of an Azure
+Network Watcher.
 
 <br />
 
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
 ## Syntax
 
-An `azurerm_network_watcher` resource block identifies a Network Watcher by
-name and resource group.
+An `azurerm_network_watcher` resource block identifies a Network Watcher by name and
+resource group.
 
     describe azurerm_network_watcher(resource_group: 'example', name: 'WatcherName') do
       ...
     end
+
 <br />
 
 ## Examples
@@ -38,8 +54,8 @@ name and resource group.
 
 ## Parameters
 
-* `name`
-* `resource_group`
+  - `name`
+  - `resource_group`
 
 ## Parameter Examples
 
@@ -51,7 +67,7 @@ The Resource Group as well as the Network Watcher name.
 
 ## Properties
 
-* `provisioning_state`
+  - `provisioning_state`
 
 ### provisioning\_state
 
@@ -61,18 +77,20 @@ The provisioning\_state field can be checked for the value of the Provisioning S
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
-The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
+The control will pass if the resource returns a result. Use `should_not` if you expect
+zero matches.
 
     # If we expect 'WatcherName' to always exist
     describe azurerm_network_watcher(resource_group: 'example', name: 'WatcherName') do
       it { should exist }
     end
-
+    
     # If we expect 'WatcherNotFound' to never exist
     describe azurerm_network_watcher(resource_group: 'example', name: 'WatcherNotFound') do
       it { should_not exist }
@@ -80,5 +98,6 @@ The control will pass if the resource returns a result. Use `should_not` if you 
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_network_watchers.md.erb
+++ b/docs/resources/azurerm_network_watchers.md.erb
@@ -5,17 +5,35 @@ platform: azure
 
 # azurerm\_network\_watchers
 
-Use the `azurerm_network_watchers` InSpec audit resource to verify that a Network Watcher exists.
+Use the `azurerm_network_watchers` InSpec audit resource to verify that a Network Watcher
+exists.
 
 <br />
 
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
 ## Syntax
 
-An `azurerm_network_watchers` resource block identifies Network Watchers by Resource Group.
+An `azurerm_network_watchers` resource block identifies Network Watchers by Resource
+Group.
 
     describe azurerm_network_watchers(resource_group: 'example_group') do
       ...
     end
+
 <br />
 
 ## Examples
@@ -30,7 +48,7 @@ An `azurerm_network_watchers` resource block identifies Network Watchers by Reso
 
 ## Properties
 
-* `names`
+  - `names`
 
 ### names
 
@@ -40,18 +58,20 @@ The name of the Network Watcher
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
-The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
+The control will pass if the resource returns a result. Use `should_not` if you expect
+zero matches.
 
     # If we expect 'ExampleGroup' Resource Group to have Network Watchers
     describe azurerm_network_watchers(resource_group: 'ExampleGroup') do
       it { should exist }
     end
-
+    
     # If we expect 'MissingExampleGroup' Resource Group to not have Network Watchers
     describe azurerm_network_watchers(resource_group: 'MissingExampleGroup') do
       it { should_not exist }
@@ -59,5 +79,6 @@ The control will pass if the resource returns a result. Use `should_not` if you 
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_resource_groups.md.erb
+++ b/docs/resources/azurerm_resource_groups.md.erb
@@ -8,10 +8,29 @@ platform: azure
 Use the `azurerm_resource_groups` InSpec audit resource to test properties of
 some or all Azure Resource Groups
 
-A Resource Group is a grouping of Azure resources. This allows you to issue a
-common command on a group of resources.
+A Resource Group is a grouping of Azure resources. This allows you to issue a common
+command on a group of resources.
 
 <br />
+
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
+### Version
+
+This resource first became available in 1.0.0 of the inspec-azure resource pack.
 
 ## Syntax
 
@@ -52,12 +71,12 @@ The following examples show how to use this InSpec audit resource.
 
 ## Filter Criteria
 
-* `names`
+  - `names`
 
 ### names
 
-Filters the results to include only those resource groups that match the given
-name. This is a string value.
+Filters the results to include only those resource groups that match the given name. This
+is a string value.
 
     describe azurerm_resource_groups.where { name.start_with?('InSpec') } do
       it { should exist }
@@ -65,7 +84,7 @@ name. This is a string value.
 
 ## Properties
 
-* `names`
+  - `names`
 
 ### names
 
@@ -75,14 +94,14 @@ The names property provides a list of all the Resource Group names.
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
 page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
-The control will pass if the filter returns at least one result. Use
-`should_not` if you expect zero matches.
+The control will pass if the filter returns at least one result. Use `should_not` if you
+expect zero matches.
 
     describe azurerm_resource_groups do
       it { should exist }
@@ -90,5 +109,6 @@ The control will pass if the filter returns at least one result. Use
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_security_center_policies.md.erb
+++ b/docs/resources/azurerm_security_center_policies.md.erb
@@ -8,10 +8,29 @@ platform: azure
 Use the `azurerm_security_center_policies` InSpec audit resource to test
 properties of some or all Azure Security Center Policies.
 
-Security Center Policies are defined for each Resource Group. A Security Center
-Policy called `default` also exists for every subscription.
+Security Center Policies are defined for each Resource Group. A Security Center Policy
+called `default` also exists for every subscription.
 
 <br />
+
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
+### Version
+
+This resource first became available in 1.0.0 of the inspec-azure resource pack.
 
 ## Syntax
 
@@ -43,12 +62,12 @@ exist.
 
 ## Filter Criteria
 
-* `names`
+  - `names`
 
 ### names
 
-Filters the results to include only those Security Center Policies that match
-the given name. This is a string value.
+Filters the results to include only those Security Center Policies that match the given
+name. This is a string value.
 
     # default should always exist
     describe azurerm_security_center_policies.where('name' => 'default')
@@ -57,14 +76,14 @@ the given name. This is a string value.
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
 page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
-The control will pass if the filter returns at least one result. Use
-`should_not` if you expect zero matches.
+The control will pass if the filter returns at least one result. Use `should_not` if you
+expect zero matches.
 
     # default should always exist
     describe azurerm_security_center_policies.where('name' => 'default')
@@ -78,5 +97,6 @@ The control will pass if the filter returns at least one result. Use
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_security_center_policy.md.erb
+++ b/docs/resources/azurerm_security_center_policy.md.erb
@@ -10,12 +10,31 @@ of the `default` Security Center Policy. Azure currently only supports looking
 up the `default` policy via their Rest API. If you attempt to look up a
 different Security Policy you will receive an error.
 
-An Azure Security Center Policy defines a set of controls recommended for
-resources within this subscription. These settings will generate alerts if
-something is found to violate the recommendations. This resource allows you to
-inspect what alerts you have configured for your account.
+An Azure Security Center Policy defines a set of controls recommended for resources within
+this subscription. These settings will generate alerts if something is found to violate
+the recommendations. This resource allows you to inspect what alerts you have configured
+for your account.
 
 <br />
+
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
+### Version
+
+This resource first became available in 1.0.0 of the inspec-azure resource pack.
 
 ## Syntax
 
@@ -26,6 +45,7 @@ If no policy is given the default one will be used.
     describe azurerm_security_center_policy(name: 'default') do
       ...
     end
+
 <br />
 
 ## Examples
@@ -52,11 +72,12 @@ If no policy is given the default one will be used.
 
 ## Parameters
 
-* `name`
+  - `name`
 
 ## Parameter Examples
 
-The name of the Security Center Policy. It must be `default`. If no name is given then it will search for the `default` Security Center Policy (Optional).
+The name of the Security Center Policy. It must be `default`. If no name is given then it
+will search for the `default` Security Center Policy (Optional).
 
     describe azurerm_security_center_policy(name: 'default') do
       its('log_collection') { should eq('On') }
@@ -64,11 +85,17 @@ The name of the Security Center Policy. It must be `default`. If no name is give
 
 ## Properties
 
-* `id`, `name`, `log_collection`, `patch`, `baseline`, `anti_malware`, `disk_encryption`, `network_security_groups`, `web_application_firewall`, `next_generation_firewall`, `vulnerability_assessment`, `just_in_time_network_access`, `app_whitelisting`, `sql_auditing`, `sql_transparent_data_encryption`, `notifications_enabled`, `send_security_email_to_admin`, `contact_emails`, `contact_phone`
+  - `id`, `name`, `log_collection`, `patch`, `baseline`, `anti_malware`,
+    `disk_encryption`, `network_security_groups`, `web_application_firewall`,
+    `next_generation_firewall`, `vulnerability_assessment`, `just_in_time_network_access`,
+    `app_whitelisting`, `sql_auditing`, `sql_transparent_data_encryption`,
+    `notifications_enabled`, `send_security_email_to_admin`, `contact_emails`,
+    `contact_phone`
 
 ### id
 
-The id of the Security Center Policy.
+The id of the Security Center
+    Policy.
 
     its('id') { should eq('/subscriptions/<SUBSCRIPTION_ID>/providers/Microsoft.Security/policies/default') }
 
@@ -92,49 +119,57 @@ Patch indicates if system updates should be enabled for virtual machines (`On`|`
 
 ### baseline
 
-Baseline indicates if OS vulnerabilities recommendations for virtual machines are enabled (`On`|`Off`).
+Baseline indicates if OS vulnerabilities recommendations for virtual machines are enabled
+(`On`|`Off`).
 
     its('baseline') { should eq('On') }
 
 ### anti\_malware
 
-Anti-Malware indicates if endpoint protection recommendations for virtual machines are enabled (`On`|`Off`).
+Anti-Malware indicates if endpoint protection recommendations for virtual machines are
+enabled (`On`|`Off`).
 
     its('anti_malware') { should eq('On') }
 
 ### disk\_encryption
 
-Disk Encryption indicates if recommendations for virtual machines are enabled (`On`|`Off`).
+Disk Encryption indicates if recommendations for virtual machines are enabled
+(`On`|`Off`).
 
     its('disk_encryption') { should eq('On') }
 
 ### network\_security\_groups
 
-Network security groups indicates if recommendations for virtual machines are enabled (`On`|`Off`).
+Network security groups indicates if recommendations for virtual machines are enabled
+(`On`|`Off`).
 
     its('network_security_groups') { should eq('On') }
 
 ### web\_application\_firewall
 
-Web application firewall indicates if recommendations for virtual machines are enabled (`On`|`Off`).
+Web application firewall indicates if recommendations for virtual machines are enabled
+(`On`|`Off`).
 
     its('web_application_firewall') { should eq('On') }
 
 ### next\_generation\_firewall
 
-Next generation firewall indicates if recommendations for virtual machines are enabled (`On`|`Off`).
+Next generation firewall indicates if recommendations for virtual machines are enabled
+(`On`|`Off`).
 
     its('next_generation_firewall') { should eq('On') }
 
 ### vulnerability\_assessment
 
-Vulnerability assessment indicates if recommendations for virtual machines are enabled (`On`|`Off`).
+Vulnerability assessment indicates if recommendations for virtual machines are enabled
+(`On`|`Off`).
 
     its('vulnerability_assessment') { should eq('On') }
 
 ### just\_in\_time\_network\_access
 
-Just in time network access indicates if recommendations for virtual machines are enabled (`On`|`Off`).
+Just in time network access indicates if recommendations for virtual machines are enabled
+(`On`|`Off`).
 
     its('just_in_time_network_access') { should eq('On') }
 
@@ -146,7 +181,8 @@ App whitelisting indicates if adaptive application controls are enabled (`On`|`O
 
 ### sql\_auditing
 
-SQL auditing indicates if auditing and threat detection recommendations are enabled (`On`|`Off`).
+SQL auditing indicates if auditing and threat detection recommendations are enabled
+(`On`|`Off`).
 
     its('sql_auditing') { should eq('On') }
 
@@ -158,13 +194,15 @@ SQL transparent data encryption indicates if recommendations are enabled (`On`|`
 
 ### notifications\_enabled
 
-Notifications enabled indicates if security alerts are emailed to the security contact (`true`|`false`).
+Notifications enabled indicates if security alerts are emailed to the security contact
+(`true`|`false`).
 
     its('notifications_enabled') { should eq(true) }
 
 ### send\_security\_email\_to\_admin
 
-Send security email to admin indicates if the subscription admin will receive security alerts (`true`|`false`).
+Send security email to admin indicates if the subscription admin will receive security
+alerts (`true`|`false`).
 
     its('send_security_email_to_admin') { should eq(true) }
 
@@ -182,12 +220,14 @@ Contact phone contains the security contact phone number.
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
-The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
+The control will pass if the resource returns a result. Use `should_not` if you expect
+zero matches.
 
     # default should always exist
     describe azurerm_security_center_policy(name: 'default') do
@@ -201,5 +241,6 @@ The control will pass if the resource returns a result. Use `should_not` if you 
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_virtual_machine.md.erb
+++ b/docs/resources/azurerm_virtual_machine.md.erb
@@ -6,7 +6,7 @@ platform: azure
 # azurerm\_virtual\_machine
 
 Use the `azurerm_virtual_machine` InSpec audit resource to test properties related to a
-virtual machines.
+virtual machine.
 
 <br />
 
@@ -164,7 +164,7 @@ page](https://www.inspec.io/docs/reference/matchers/).
     describe azurerm_virtual_machine(resource_group: 'MyResourceGroup', name: 'MyVmName') do
       it { should exist }
     end
-    
+
     # virtual machines that aren't found will not exist
     describe azurerm_virtual_machine(resource_group: 'MyResourceGroup', name: 'DoesNotExist') do
       it { should_not exist }

--- a/docs/resources/azurerm_virtual_machine.md.erb
+++ b/docs/resources/azurerm_virtual_machine.md.erb
@@ -5,14 +5,34 @@ platform: azure
 
 # azurerm\_virtual\_machine
 
-Use the `azurerm_virtual_machine` InSpec audit resource to test properties
-related to a virtual machines.
+Use the `azurerm_virtual_machine` InSpec audit resource to test properties related to a
+virtual machines.
 
 <br />
 
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
+### Version
+
+This resource first became available in 1.0.0 of the inspec-azure resource pack.
+
 ## Syntax
 
-The `resource_group` and virtual machine `name` must be given as parameters.
+The `resource_group` and virtual machine `name` must be given as
+    parameters.
 
     describe azurerm_virtual_machine(resource_group: 'MyResourceGroup', name: 'MyVmName') do
       ...
@@ -39,13 +59,14 @@ The `resource_group` and virtual machine `name` must be given as parameters.
 
 ## Parameters
 
-* `resource_group`, `name`
+  - `resource_group`, `name`
 
 ## Parameter Examples
 
 ### resource\_group (required)
 
-Defines the resource group that the virtual machine that you wish to test resides in.
+Defines the resource group that the virtual machine that you wish to test resides
+    in.
 
     describe azurerm_virtual_machine(resource_group: 'MyResourceGroup', name: 'MyVmName') do
       ...
@@ -53,7 +74,8 @@ Defines the resource group that the virtual machine that you wish to test reside
 
 ### name (required)
 
-Defines the name of the virtual machine that you wish to test.
+Defines the name of the virtual machine that you wish to
+    test.
 
     describe azurerm_virtual_machine(resource_group: 'MyResourceGroup', name: 'MyVmName') do
       ...
@@ -61,7 +83,9 @@ Defines the name of the virtual machine that you wish to test.
 
 ## Properties
 
-* `id`, `name`, `location`, `properties`, `resources`, `tags`, `type`, `zones`, `installed_extensions_types`, `installed_extensions_names`, `monitoring_agent_installed`, `os_disk_name`, `data_disk_names`
+  - `id`, `name`, `location`, `properties`, `resources`, `tags`, `type`, `zones`,
+    `installed_extensions_types`, `installed_extensions_names`,
+    `monitoring_agent_installed`, `os_disk_name`, `data_disk_names`
 
 ### id
 
@@ -69,7 +93,8 @@ The virtual machine's id.
 
     its('id') { should eq(id) }
 
-Id will be in format:
+Id will be in
+    format:
 
     '/subscriptions/<SUBSCRIPTION_ID>/resourceGroups/MyResourceGroup/providers/Microsoft.Compute/virtualMachines/MyVirtualMachine'
 
@@ -129,8 +154,9 @@ List of all installed extensions' names for the virtual machine.
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
@@ -138,7 +164,7 @@ of available matchers, please visit our [Universal Matchers page](https://www.in
     describe azurerm_virtual_machine(resource_group: 'MyResourceGroup', name: 'MyVmName') do
       it { should exist }
     end
-
+    
     # virtual machines that aren't found will not exist
     describe azurerm_virtual_machine(resource_group: 'MyResourceGroup', name: 'DoesNotExist') do
       it { should_not exist }
@@ -168,5 +194,6 @@ of available matchers, please visit our [Universal Matchers page](https://www.in
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_virtual_machine_disk.md.erb
+++ b/docs/resources/azurerm_virtual_machine_disk.md.erb
@@ -32,8 +32,7 @@ This resource first became available in 1.0.0 of the inspec-azure resource pack.
 
 ## Syntax
 
-The `resource_group` and `name` must be given as
-    parameters.
+The `resource_group` and `name` must be given as parameters.
 
     describe azurerm_virtual_machine_disk(resource_group: 'MyResourceGroup', name: 'MyDiskName') do
       ...
@@ -47,7 +46,7 @@ The `resource_group` and `name` must be given as
     describe azurerm_virtual_machine_disk(resource_group: 'MyResourceGroup', name: 'MyDiskName') do
       it { should exist }
     end
-    
+
     # Check if encryption is enabled
     describe azurerm_virtual_machine_disk(resource_group: 'MyResourceGroup', name: 'MyDiskName') do
       it('encryption_enabled') { should be true }

--- a/docs/resources/azurerm_virtual_machine_disk.md.erb
+++ b/docs/resources/azurerm_virtual_machine_disk.md.erb
@@ -5,15 +5,35 @@ platform: azure
 
 # azurerm\_virtual\_machine\_disk
 
-Use the `azurerm_virtual_machine_disk` InSpec audit resource to test properties
-related to a virtual machine's disk. This resource will only support managed
-disks. If your disk is not managed it will not `exist` to the matcher.
+Use the `azurerm_virtual_machine_disk` InSpec audit resource to test properties related to
+a virtual machine's disk. This resource will only support managed disks. If your disk is
+not managed it will not `exist` to the matcher.
 
 <br />
 
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
+### Version
+
+This resource first became available in 1.0.0 of the inspec-azure resource pack.
+
 ## Syntax
 
-The `resource_group` and `name` must be given as parameters.
+The `resource_group` and `name` must be given as
+    parameters.
 
     describe azurerm_virtual_machine_disk(resource_group: 'MyResourceGroup', name: 'MyDiskName') do
       ...
@@ -27,7 +47,7 @@ The `resource_group` and `name` must be given as parameters.
     describe azurerm_virtual_machine_disk(resource_group: 'MyResourceGroup', name: 'MyDiskName') do
       it { should exist }
     end
-
+    
     # Check if encryption is enabled
     describe azurerm_virtual_machine_disk(resource_group: 'MyResourceGroup', name: 'MyDiskName') do
       it('encryption_enabled') { should be true }
@@ -37,7 +57,7 @@ The `resource_group` and `name` must be given as parameters.
 
 ## Parameters
 
-* `resource_group`, `name`
+  - `resource_group`, `name`
 
 ## Parameter Examples
 
@@ -48,7 +68,8 @@ The `resource_group` and `name` must be given as parameters.
 
 ## Properties
 
-* `id`, `name`, `managedBy`, `sku`, `properties`, `type`, `location`, `tags`, `encryption_enabled`
+  - `id`, `name`, `managedBy`, `sku`, `properties`, `type`, `location`, `tags`,
+    `encryption_enabled`
 
 ### id
 
@@ -56,7 +77,8 @@ The disk's unique identifier.
 
     its('id') { should eq(id) }
 
-Id will be in the format:
+Id will be in the
+    format:
 
     /subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/myManagedDisk
 
@@ -72,7 +94,8 @@ The resource managing the disk if it is attached to a virtual machine.
 
     its('managedBy') { should eq(ResourceId) }
 
-ResourceId will be in the format:
+ResourceId will be in the
+    format:
 
     /subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/myManagedDisk
 
@@ -112,8 +135,9 @@ If the disk is encrypted or not (`true`|`false`).
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
@@ -123,5 +147,6 @@ of available matchers, please visit our [Universal Matchers page](https://www.in
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azurerm_virtual_machines.md.erb
+++ b/docs/resources/azurerm_virtual_machines.md.erb
@@ -5,10 +5,29 @@ platform: azure
 
 # azurerm\_virtual\_machines
 
-Use the `azurerm\_virtual\_machines` InSpec audit resource to test properties
-related to virtual machines for a resource group.
+Use the `azurerm\_virtual\_machines` InSpec audit resource to test properties related to
+virtual machines for a resource group.
 
 <br />
+
+## Availability
+
+### Installation
+
+This resource is available in the `inspec-azure` [resource
+pack](https://www.inspec.io/docs/reference/glossary/#resource-pack). To use it, add the
+following to your `inspec.yml` in your top-level profile:
+
+    depends:
+      inspec-azure:
+        git: https://github.com/inspec/inspec-azure.git
+
+You'll also need to setup your Azure credentials; see the resource pack
+[README](https://github.com/inspec/inspec-azure#inspec-for-azure).
+
+### Version
+
+This resource first became available in 1.0.0 of the inspec-azure resource pack.
 
 ## Syntax
 
@@ -24,7 +43,7 @@ The `resource_group` must be given as a parameter.
     describe azurerm_virtual_machines(resource_group: 'MyResourceGroup') do
       it { should exist }
     end
-
+    
     # Filters based on platform
     describe azurerm_virtual_machines(resource_group: 'MyResourceGroup').where('platform' => 'windows') do
       it { should exist }
@@ -34,7 +53,7 @@ The `resource_group` must be given as a parameter.
 
 ## Parameters
 
-* `resource_group`
+  - `resource_group`
 
 ### Parameter Examples
 
@@ -48,12 +67,12 @@ The `resource_group` must be given as a parameter.
 
 ## Filter Criteria
 
-* `platform`, `name`, `os_disk`
+  - `platform`, `name`, `os_disk`
 
 ### platform
 
-Filters the results to only include those that match the given platform. Valid
-choices are `linux` and `windows`.
+Filters the results to only include those that match the given platform. Valid choices are
+`linux` and `windows`.
 
     # Insist that you have at least one windows virtual machine
     describe azurerm_virtual_machines(resource_group: 'MyResourceGroup').where('platform' => 'windows') do
@@ -71,7 +90,7 @@ Filters the result to only those that match the given name.
 
 ## Properties
 
-* `os_disks`, `data_disks`, `vm_names`
+  - `os_disks`, `data_disks`, `vm_names`
 
 ### os\_disks
 
@@ -97,8 +116,9 @@ Gives a list of all the virtual machine names in the resource group.
 
 ## Matchers
 
-This InSpec audit resource has the following special matchers. For a full list
-of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).
+This InSpec audit resource has the following special matchers. For a full list of
+available matchers, please visit our [Universal Matchers
+page](https://www.inspec.io/docs/reference/matchers/).
 
 ### exists
 
@@ -106,7 +126,7 @@ of available matchers, please visit our [Universal Matchers page](https://www.in
     describe azurerm_virtual_machines(resource_group: 'MyResourceGroup') do
       it { should_not exist }
     end
-
+    
     # Should exist if the filter returns a single virtual machine
     describe azurerm_virtual_machines(resource_group: 'MyResourceGroup').where('platform' => 'windows') do
       it { should exist }
@@ -114,5 +134,6 @@ of available matchers, please visit our [Universal Matchers page](https://www.in
 
 ## Azure Permissions
 
-Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
+Your [Service
+Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
 must be setup with a `contributor` role on the subscription you wish to test.

--- a/libraries/azure_security_center_policies.rb
+++ b/libraries/azure_security_center_policies.rb
@@ -15,6 +15,6 @@ class AzureSecurityCenterPolicies < AzurermSecurityCenterPolicies
     warn '[DEPRECATION] The `azure_security_center_policies` resource is ' \
          'deprecated and will be removed in version 2.0. Use the ' \
          '`azurerm_security_center_policies` resource instead.'
-   super
+    super
   end
 end

--- a/libraries/azurerm_ad_user.rb
+++ b/libraries/azurerm_ad_user.rb
@@ -7,7 +7,7 @@ class AzurermAdUser < AzurermSingularResource
   desc 'Verifies settings for an Azure Active Directory User'
   example <<-EXAMPLE
     describe azurerm_ad_user(user_id: 'userId') do
-      it  { should exist }
+      it { should exist }
     end
   EXAMPLE
 

--- a/libraries/support/azure/graph.rb
+++ b/libraries/support/azure/graph.rb
@@ -40,7 +40,7 @@ module Azure
 
       response = rest_client.get(*args).body
 
-      if response.has_key? 'odata.error'
+      if response.key?('odata.error')
         raise Inspec::Exceptions::ResourceFailed, format_error(response['odata.error'])
       end
 


### PR DESCRIPTION
In support of displaying the Azure resource pack docs on the main InSpec website, we need to note that these resources are distributed as a resource pack.  This PR adds such a note.

Additionally, we get a lot of confusion around when a resource first appeared (and thus minimum version needed).  This PR also adds a note to that affect, as well.

![screen shot 2018-07-05 at 22 36 18](https://user-images.githubusercontent.com/156460/42389529-0fd56cea-8117-11e8-8356-9cdf34317a6c.png)

Fixes #64 #93 