### PR TITLE
Add PowerShell ENV to Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,21 @@ export AZURE_TENANT_ID=<tenant id>
 export AZURE_CLIENT_SECRET=<client secret>
 ```
 
+For PowerShell, set the following environment variables
+```
+$env:AZURE_SUBSCRIPTION_ID="<subscription id>"
+$env:AZURE_CLIENT_ID="<client id>"
+$env:AZURE_CLIENT_SECRET="<tenant id>"
+$env:AZURE_TENANT_ID="<client secret>"
+```
+
 **Setup Azure CLI**
 - Follow the instructions for your platform [here](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
   * macOS: `brew update && brew install azure-cli`
 - Login with the azure-cli
   * `rake azure:login`
 - Verify azure-cli is logged in:
-  * az account show
+  * `az account show`
 
 ## Starting an Environment
 

--- a/Rakefile
+++ b/Rakefile
@@ -101,9 +101,9 @@ task :setup_env do
 end
 
 task :check_env do
-  REQUIRED_ENVS.each do |var|
-    abort("Missing ENV: #{var}") unless ENV.key?(var)
-  end
+  missing = REQUIRED_ENVS.reject { |var| ENV.key?(var) }
+
+  abort("ENV missing: #{missing.join(', ')}") if missing.any?
 end
 
 namespace :test do


### PR DESCRIPTION
- Add information to documentation about setting the required environment
variables for PowerShell.
- Add a Rake task to check if Azure environment variables are set and provide
a useful error message on failure.

Fixes #71