### PR TITLE
Add Integration Tests for CIS-5.x Resources

### DIFF
--- a/libraries/azure_monitor_activity_log_alert.rb
+++ b/libraries/azure_monitor_activity_log_alert.rb
@@ -6,7 +6,7 @@ class AzureMonitorActivityLogAlert < AzurermResource
   name 'azure_monitor_activity_log_alert'
   desc 'Verifies settings for a Azure Monitor Activity Log Alert'
   example <<-EXAMPLE
-    describe azure_monitor_activity_log_alert(resource_group: 'example', name: 'alert-name') do
+    describe azure_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
       it { should exist }
       its('operations') { should include 'Microsoft.Authorization/policyAssignments/write' }
     end

--- a/libraries/azure_monitor_log_profiles.rb
+++ b/libraries/azure_monitor_log_profiles.rb
@@ -7,7 +7,7 @@ class AzureMonitorLogProfiles < AzurermResource
   desc 'Fetches all Azure Monitor Log Profiles'
   example <<-EXAMPLE
     describe azure_monitor_log_profiles do
-      its('names') { should include('example-profile') }
+      its('names') { should include('default') }
     end
   EXAMPLE
 

--- a/libraries/support/azure/management.rb
+++ b/libraries/support/azure/management.rb
@@ -39,14 +39,14 @@ module Azure
       get(
         url: link(location: 'Microsoft.Insights/activityLogAlerts',
                   resource_group: resource_group) + id,
-        api_version: '2016-04-01',
+        api_version: '2017-04-01',
       )
     end
 
     def activity_log_alerts
       get(
         url: link(location: 'Microsoft.Insights/activityLogAlerts'),
-        api_version: '2016-04-01',
+        api_version: '2017-04-01',
       )
     end
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -90,3 +90,7 @@ output "network_security_group" {
 output "network_security_group_id" {
   value = "${azurerm_network_security_group.nsg.id}"
 }
+
+output "activity_log_alert_name" {
+  value = "${var.activity_log_alert["log_alert"]}"
+}

--- a/test/integration/verify/controls/azure_monitor_activity_log_alert.rb
+++ b/test/integration/verify/controls/azure_monitor_activity_log_alert.rb
@@ -1,0 +1,28 @@
+resource_group = attribute('resource_group', default: nil)
+log_alert_name = attribute('activity_log_alert_name', default: nil)
+
+alerts_and_operations = {
+  '5_3'  => 'Microsoft.Authorization/policyAssignments/write',
+  '5_4'  => 'Microsoft.Network/networkSecurityGroups/write',
+  '5_5'  => 'Microsoft.Network/networkSecurityGroups/delete',
+  '5_6'  => 'Microsoft.Network/networkSecurityGroups/securityRules/write',
+  '5_7'  => 'Microsoft.Network/networkSecurityGroups/securityRules/delete',
+  '5_8'  => 'Microsoft.Security/securitySolutions/write',
+  '5_9'  => 'Microsoft.Security/securitySolutions/delete',
+  '5_10' => 'Microsoft.Sql/servers/firewallRules/write',
+  '5_11' => 'Microsoft.Sql/servers/firewallRules/delete',
+  '5_12' => 'Microsoft.Security/policies/write',
+}
+
+control 'azure_monitor_activity_log_alert' do
+  alerts_and_operations.each do |alert, operation|
+    describe azure_monitor_activity_log_alert(resource_group: resource_group, name: "#{log_alert_name}_#{alert}") do
+      it                { should exist }
+      its('operations') { should include operation }
+    end
+  end
+
+  describe azure_monitor_activity_log_alert(resource_group: resource_group, name: 'fake') do
+    it { should_not exist }
+  end
+end

--- a/test/integration/verify/controls/azure_monitor_activity_log_alerts.rb
+++ b/test/integration/verify/controls/azure_monitor_activity_log_alerts.rb
@@ -1,0 +1,5 @@
+control 'azure_monitor_activity_log_alerts' do
+  describe azure_monitor_activity_log_alerts do
+    its('names') { should include('defaultLogAlert_5_3') }
+  end
+end

--- a/test/integration/verify/controls/azure_monitor_log_profile.rb
+++ b/test/integration/verify/controls/azure_monitor_log_profile.rb
@@ -1,0 +1,7 @@
+control 'azure_monitor_activity_log_profile' do
+  describe azure_monitor_log_profile(name: 'default') do
+    it { should exist }
+    its('retention_enabled') { should be true }
+    its('retention_days')    { should eq(365) }
+  end
+end

--- a/test/integration/verify/controls/azure_monitor_log_profiles.rb
+++ b/test/integration/verify/controls/azure_monitor_log_profiles.rb
@@ -1,0 +1,5 @@
+control 'azure_monitor_activity_log_prolfiles' do
+  describe azure_monitor_log_profiles do
+    its('names') { should include('default') }
+  end
+end


### PR DESCRIPTION
Add InSpec integration tests for the resources that were
added for CIS-5.x benchmarks.

Add TerraForm Output that can be used with new integration tests.

This also fixes the Azure API endpoint uses for Log Alerts. The API
was returning an error about a wrong API version number. This corrects
it to the one provided by the error message.

Fixes #80