### PR TITLE
Extract common features of Azure service proxies

### DIFF
--- a/libraries/support/azure.rb
+++ b/libraries/support/azure.rb
@@ -3,5 +3,6 @@
 require 'support/azure/authentication'
 require 'support/azure/rest'
 require 'support/azure/credentials'
+require 'support/azure/service'
 require 'support/azure/management'
 require 'support/azure/graph'

--- a/libraries/support/azure/management.rb
+++ b/libraries/support/azure/management.rb
@@ -1,38 +1,15 @@
 # frozen_string_literal: true
 
-require 'json'
 require 'singleton'
 
 module Azure
   class Management
     include Singleton
-
-    class Cache
-      def initialize
-        @store = {}
-      end
-
-      def fetch(key)
-        @store.fetch(key) { @store[key] = yield }
-      end
-    end
-
-    attr_reader :cache
+    include Service
 
     def initialize
-      @cache = Cache.new
-    end
-
-    def with_cache(cache)
-      @cache = cache
-    end
-
-    def with_client(rest_client, override: false)
-      set_reader(:rest_client, rest_client, override)
-    end
-
-    def for_subscription(subscription_id, override: false)
-      set_reader(:subscription_id, subscription_id, override)
+      @required_attrs = %i(rest_client subscription_id)
+      @page_link_name = 'nextLink'
     end
 
     def activity_log_alert(resource_group, id)
@@ -152,31 +129,6 @@ module Azure
       "#{"/resourceGroups/#{resource_group}" if resource_group}" \
       "#{'/providers' if provider}" \
       "/#{location}/"
-    end
-
-    def get(url:, api_version:)
-      confirm_configured!
-
-      cache.fetch(url) do
-        body = rest_client.get(url, params: { 'api-version' => api_version }).body
-        body.fetch('value', body)
-      end
-    end
-
-    def confirm_configured!
-      %i(rest_client subscription_id).each do |name|
-        next if respond_to?(name)
-
-        raise "Set #{name} before making requests"
-      end
-    end
-
-    def set_reader(name, value, override)
-      return self if respond_to?(name) && !override
-
-      define_singleton_method(name) { value }
-
-      self
     end
   end
 end

--- a/libraries/support/azure/service.rb
+++ b/libraries/support/azure/service.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Azure
+  module Service
+    class Cache
+      def initialize
+        @store = {}
+      end
+
+      def fetch(key)
+        @store.fetch(key) { @store[key] = yield }
+      end
+    end
+
+    def with_cache(cache)
+      @cache = cache
+    end
+
+    def with_client(graph_client, override: false)
+      set_reader(:rest_client, graph_client, override)
+    end
+
+    def for_tenant(tenant_id, override: false)
+      set_reader(:tenant_id, tenant_id, override)
+    end
+
+    def for_subscription(subscription_id, override: false)
+      set_reader(:subscription_id, subscription_id, override)
+    end
+
+    private
+
+    attr_reader :required_attrs
+
+    def cache
+      @cache ||= Cache.new
+    end
+
+    def confirm_configured!
+      required_attrs.each do |name|
+        next if respond_to?(name)
+
+        raise "Set #{name} before making requests"
+      end
+    end
+
+    def set_reader(name, value, override)
+      return self if respond_to?(name) && !override
+
+      define_singleton_method(name) { value }
+
+      self
+    end
+
+    def get(url:, api_version:)
+      confirm_configured!
+
+      cache.fetch(url) do
+        body = rest_client.get(url, params: { 'api-version' => api_version }).body
+        body.fetch('value', body)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I think these are the intermediary steps between the code you have now in #70 and what we're talking about with regard to `get` and paging....

The service classes should represent their unique features, and the common code required to work with them should be extracted to a shared module. This change does so.

Next steps would be:
 * Update `Graph#get()` to use the cache
 * Move `Graph#get()` to `Service`, replacing the one extracted from `Management`
 * Maybe find some smoother way to define the particulars of each class, rather than instance variables in `initialize`

Signed-off-by: Trevor Bramble <tbramble@chef.io>