### PR TITLE
Rename azure_network_security_group(s) resources to azurerm_network_security_group(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,18 +76,20 @@ end
 
 The following resources are available in the InSpec Azure Resource Pack
 
-- [azurerm_virtual_machine](docs/resources/azurerm_virtual_machine.md.erb)
 - [azure_monitor_activity_log_alert](docs/resources/azure_monitor_activity_log_alert.md.erb)
-- [azurerm_virtual_machine_disk](docs/resources/azurerm_virtual_machine_disk.md.erb)
-- [azure_resource_groups](docs/resources/azure_resource_groups.md.erb)
 - [azure_monitor_activity_log_alerts](docs/resources/azure_monitor_activity_log_alerts.md.erb)
-- [azurerm_virtual_machines](docs/resources/azurerm_virtual_machines.md.erb)
+- [azure_monitor_log_profile](docs/resources/azure_monitor_log_profile.md.erb)
 - [azure_monitor_log_profiles](docs/resources/azure_monitor_log_profiles.md.erb)
 - [azure_network_watcher](docs/resources/azure_network_watcher.md.erb)
-- [azure_monitor_log_profile](docs/resources/azure_monitor_log_profile.md.erb)
-- [azure_security_center_policies](docs/resources/azure_security_center_policies.md.erb)
 - [azure_network_watchers](docs/resources/azure_network_watchers.md.erb)
+- [azure_resource_groups](docs/resources/azure_resource_groups.md.erb)
+- [azure_security_center_policies](docs/resources/azure_security_center_policies.md.erb)
 - [azure_security_center_policy](docs/resources/azure_security_center_policy.md.erb)
+- [azurerm_network_security_group](docs/resources/azurerm_network_security_group.md.erb)
+- [azurerm_network_security_groups](docs/resources/azurerm_network_security_groups.md.erb)
+- [azurerm_virtual_machine](docs/resources/azurerm_virtual_machine.md.erb)
+- [azurerm_virtual_machine_disk](docs/resources/azurerm_virtual_machine_disk.md.erb)
+- [azurerm_virtual_machines](docs/resources/azurerm_virtual_machines.md.erb)
 
 
 ## Development

--- a/docs/resources/azurerm_network_security_group.md.erb
+++ b/docs/resources/azurerm_network_security_group.md.erb
@@ -1,21 +1,21 @@
 ---
-title: About the azure_network_security_group Resource
+title: About the azurerm_network_security_group Resource
 platform: azure
 ---
 
-# azure\_network\_security\_group
+# azurerm\_network\_security\_group
 
-Use the `azure_network_security_group` InSpec audit resource to test properties
+Use the `azurerm_network_security_group` InSpec audit resource to test properties
 of an Azure Network Security Group.
 
 <br />
 
 ## Syntax
 
-An `azure_network_security_group` resource block identifies a Network Security Group by
+An `azurerm_network_security_group` resource block identifies a Network Security Group by
 name and Resource Group.
 
-    describe azure_network_security_group(resource_group: 'example', name: 'GroupName') do
+    describe azurerm_network_security_group(resource_group: 'example', name: 'GroupName') do
       ...
     end
 <br />
@@ -24,13 +24,13 @@ name and Resource Group.
 
 ### Test that an example Resource Group has the specified Network Security Group
 
-    describe azure_network_security_group(resource_group: 'example', name: 'GroupName') do
+    describe azurerm_network_security_group(resource_group: 'example', name: 'GroupName') do
       it { should exist }
     end
 
 ### Test that an example Resource Group has a Network Security Group that allows SSH from the internet
 
-    describe azure_network_security_group(resource_group: 'example', name: 'GroupName') do
+    describe azurerm_network_security_group(resource_group: 'example', name: 'GroupName') do
       it { should allow_ssh_from_internet }
     end
 
@@ -45,7 +45,7 @@ name and Resource Group.
 
 The Resource Group as well as the Network Security Group name.
 
-    describe azure_network_security_group(resource_group: 'example', name: 'GroupName') do
+    describe azurerm_network_security_group(resource_group: 'example', name: 'GroupName') do
       it { should allow_rdp_from_internet }
     end
 
@@ -92,12 +92,12 @@ of available matchers, please visit our [Universal Matchers page](https://www.in
 The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
 
     # If we expect 'GroupName' to always exist
-    describe azure_network_security_group(resource_group: 'example', name: 'GroupName') do
+    describe azurerm_network_security_group(resource_group: 'example', name: 'GroupName') do
       it { should exist }
     end
 
     # If we expect 'EmptyGroupName' to never exist
-    describe azure_network_security_group(resource_group: 'example', name: 'EmptyGroupName') do
+    describe azurerm_network_security_group(resource_group: 'example', name: 'EmptyGroupName') do
       it { should_not exist }
     end
 

--- a/docs/resources/azurerm_network_security_groups.md.erb
+++ b/docs/resources/azurerm_network_security_groups.md.erb
@@ -1,21 +1,21 @@
 ---
-title: About the azure_network_security_groups Resource
+title: About the azurerm_network_security_groups Resource
 platform: azure
 ---
 
-# azure\_network\_security\_groups
+# azurerm\_network\_security\_groups
 
-Use the `azure_network_security_groups` InSpec audit resource to enumerate
+Use the `azurerm_network_security_groups` InSpec audit resource to enumerate
 Network Security Groups.
 
 <br />
 
 ## Syntax
 
-An `azure_network_security_groups` resource block identifies Network Security
+An `azurerm_network_security_groups` resource block identifies Network Security
 Groups by Resource Group.
 
-    describe azure_network_security_groups(resource_group: 'ExampleGroup') do
+    describe azurerm_network_security_groups(resource_group: 'ExampleGroup') do
       ...
     end
 
@@ -25,7 +25,7 @@ Groups by Resource Group.
 
 ### Test that an example Resource Group has the named Network Security Group
 
-    describe azure_network_security_groups(resource_group: 'ExampleGroup') do
+    describe azurerm_network_security_groups(resource_group: 'ExampleGroup') do
       its('names') { should include('ExampleNetworkSecurityGroup') }
     end
 
@@ -51,12 +51,12 @@ of available matchers, please visit our [Universal Matchers page](https://www.in
 The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
 
     # If we expect 'ExampleGroup' Resource Group to have Network Security Groups
-    describe azure_network_security_groups(resource_group: 'ExampleGroup') do
+    describe azurerm_network_security_groups(resource_group: 'ExampleGroup') do
       it { should exist }
     end
 
     # If we expect 'EmptyExampleGroup' Resource Group to not have Network Security Groups
-    describe azure_network_security_groups(resource_group: 'EmptyExampleGroup') do
+    describe azurerm_network_security_groups(resource_group: 'EmptyExampleGroup') do
       it { should_not exist }
     end
 

--- a/libraries/azure_network_security_group.rb
+++ b/libraries/azure_network_security_group.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'azurerm_resource'
+require 'azurerm_network_security_group'
 
-class AzureNetworkSecurityGroup < AzurermResource
+class AzureNetworkSecurityGroup < AzurermNetworkSecurityGroup
   name 'azure_network_security_group'
   desc 'Verifies settings for Network Security Groups'
   example <<-EXAMPLE
@@ -11,97 +11,8 @@ class AzureNetworkSecurityGroup < AzurermResource
     end
   EXAMPLE
 
-  ATTRS = %i(
-    name
-    id
-    etag
-    type
-    location
-    tags
-    properties
-  ).freeze
-
-  attr_reader(*ATTRS)
-
   def initialize(resource_group: nil, name: nil)
-    resp = client.network_security_group(resource_group, name)
-    return if resp.nil? || resp.key?('error')
-
-    ATTRS.each do |field|
-      instance_variable_set("@#{field}", resp[field.to_s])
-    end
-
-    @exists = true
-  end
-
-  def to_s
-    "'#{name}' Network Security Group"
-  end
-
-  def security_rules
-    @security_rules ||= @properties['securityRules']
-  end
-
-  def default_security_rules
-    @default_security_rules ||= @properties['defaultSecurityRules']
-  end
-
-  SSH_CRITERIA = %i(ssh_port access_allow direction_inbound tcp source_open).freeze
-  def allow_ssh_from_internet?
-    @allow_ssh_from_internet ||= matches_criteria?(SSH_CRITERIA, security_rules_properties)
-  end
-  RSpec::Matchers.alias_matcher :allow_ssh_from_internet, :be_allow_ssh_from_internet
-
-  RDP_CRITERIA = %i(rdp_port access_allow direction_inbound tcp source_open).freeze
-  def allow_rdp_from_internet?
-    @allow_rdp_from_internet ||= matches_criteria?(RDP_CRITERIA, security_rules_properties)
-  end
-  RSpec::Matchers.alias_matcher :allow_rdp_from_internet, :be_allow_rdp_from_internet
-
-  private
-
-  def security_rules_properties
-    security_rules.collect { |rule| rule['properties'] }
-  end
-
-  def matches_criteria?(criteria, properties)
-    properties.any? { |property| criteria.all? { |method| send(:"#{method}?", property) } }
-  end
-
-  def ssh_port?(properties)
-    matches_port?(destination_port_ranges(properties), '22')
-  end
-
-  def rdp_port?(properties)
-    matches_port?(destination_port_ranges(properties), '3389')
-  end
-
-  def destination_port_ranges(properties)
-    return Array(properties['destinationPortRange']) if properties['destinationPortRanges'].empty?
-    return properties['destinationPortRanges'] if properties['destinationPortRange'].empty?
-    properties['destinationPortRanges'].push(properties['destinationPortRange'])
-  end
-
-  def matches_port?(ports, match_port)
-    return true if ports.detect { |p| p =~ /^(#{match_port}|\*)$/ }
-    ports.select { |port| port.include?('-') }
-         .collect { |range| range.split('-') }
-         .any? { |range| (range.first..range.last).cover?(match_port) }
-  end
-
-  def tcp?(properties)
-    properties['protocol'].casecmp?('TCP')
-  end
-
-  def access_allow?(properties)
-    properties['access'] == 'Allow'
-  end
-
-  def source_open?(properties)
-    properties['sourceAddressPrefix'] =~ %r{\*|0\.0\.0\.0|<nw>\/0|\/0|internet|any}
-  end
-
-  def direction_inbound?(properties)
-    properties['direction'] == 'Inbound'
+    warn '[DEPRECATION] The `azure_network_security_group` resource is deprecated and will be removed in version 2.0. Use the `azurerm_network_security_group` resource instead.'
+    super
   end
 end

--- a/libraries/azure_network_security_groups.rb
+++ b/libraries/azure_network_security_groups.rb
@@ -1,33 +1,18 @@
 # frozen_string_literal: true
 
-require 'azurerm_resource'
+require 'azurerm_network_security_groups'
 
-class AzureNetworkSecurityGroups < AzurermResource
+class AzureNetworkSecurityGroups < AzurermNetworkSecurityGroups
   name 'azure_network_security_groups'
-  desc 'Verifies settings for Network Security Groups'
+  desc '[DEPRECATED] Please use azurerm_network_security_groups'
   example <<-EXAMPLE
     azure_network_security_groups(resource_group: 'example') do
       it{ should exist }
     end
   EXAMPLE
 
-  attr_reader :table
-
-  FilterTable.create
-             .add_accessor(:entries)
-             .add_accessor(:where)
-             .add(:exists?) { |obj| !obj.entries.empty? }
-             .add(:names, field: 'name')
-             .connect(self, :table)
-
   def initialize(resource_group: nil)
-    resp = client.network_security_groups(resource_group)
-    return if resp.nil? || (resp.is_a?(Hash) && resp.key?('error'))
-
-    @table = resp
-  end
-
-  def to_s
-    'Network Security Groups'
+    warn '[DEPRECATION] The `azure_network_security_groups` resource is deprecated and will be removed in version 2.0. Use the `azurerm_network_security_groups` resource instead.'
+    super
   end
 end

--- a/libraries/azurerm_network_security_group.rb
+++ b/libraries/azurerm_network_security_group.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'azurerm_resource'
+
+class AzurermNetworkSecurityGroup < AzurermResource
+  name 'azurerm_network_security_group'
+  desc 'Verifies settings for Network Security Groups'
+  example <<-EXAMPLE
+    describe azurerm_network_security_group(resource_group: 'example', name: 'name') do
+      its(name) { should eq 'name'}
+    end
+  EXAMPLE
+
+  ATTRS = %i(
+    name
+    id
+    etag
+    type
+    location
+    tags
+    properties
+  ).freeze
+
+  attr_reader(*ATTRS)
+
+  def initialize(resource_group: nil, name: nil)
+    resp = client.network_security_group(resource_group, name)
+    return if resp.nil? || resp.key?('error')
+
+    ATTRS.each do |field|
+      instance_variable_set("@#{field}", resp[field.to_s])
+    end
+
+    @exists = true
+  end
+
+  def to_s
+    "'#{name}' Network Security Group"
+  end
+
+  def security_rules
+    @security_rules ||= @properties['securityRules']
+  end
+
+  def default_security_rules
+    @default_security_rules ||= @properties['defaultSecurityRules']
+  end
+
+  SSH_CRITERIA = %i(ssh_port access_allow direction_inbound tcp source_open).freeze
+  def allow_ssh_from_internet?
+    @allow_ssh_from_internet ||= matches_criteria?(SSH_CRITERIA, security_rules_properties)
+  end
+  RSpec::Matchers.alias_matcher :allow_ssh_from_internet, :be_allow_ssh_from_internet
+
+  RDP_CRITERIA = %i(rdp_port access_allow direction_inbound tcp source_open).freeze
+  def allow_rdp_from_internet?
+    @allow_rdp_from_internet ||= matches_criteria?(RDP_CRITERIA, security_rules_properties)
+  end
+  RSpec::Matchers.alias_matcher :allow_rdp_from_internet, :be_allow_rdp_from_internet
+
+  private
+
+  def security_rules_properties
+    security_rules.collect { |rule| rule['properties'] }
+  end
+
+  def matches_criteria?(criteria, properties)
+    properties.any? { |property| criteria.all? { |method| send(:"#{method}?", property) } }
+  end
+
+  def ssh_port?(properties)
+    matches_port?(destination_port_ranges(properties), '22')
+  end
+
+  def rdp_port?(properties)
+    matches_port?(destination_port_ranges(properties), '3389')
+  end
+
+  def destination_port_ranges(properties)
+    return Array(properties['destinationPortRange']) if properties['destinationPortRanges'].empty?
+    return properties['destinationPortRanges'] if properties['destinationPortRange'].empty?
+    properties['destinationPortRanges'].push(properties['destinationPortRange'])
+  end
+
+  def matches_port?(ports, match_port)
+    return true if ports.detect { |p| p =~ /^(#{match_port}|\*)$/ }
+    ports.select { |port| port.include?('-') }
+         .collect { |range| range.split('-') }
+         .any? { |range| (range.first..range.last).cover?(match_port) }
+  end
+
+  def tcp?(properties)
+    properties['protocol'].casecmp?('TCP')
+  end
+
+  def access_allow?(properties)
+    properties['access'] == 'Allow'
+  end
+
+  def source_open?(properties)
+    properties['sourceAddressPrefix'] =~ %r{\*|0\.0\.0\.0|<nw>\/0|\/0|internet|any}
+  end
+
+  def direction_inbound?(properties)
+    properties['direction'] == 'Inbound'
+  end
+end

--- a/libraries/azurerm_network_security_groups.rb
+++ b/libraries/azurerm_network_security_groups.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'azurerm_resource'
+
+class AzurermNetworkSecurityGroups < AzurermResource
+  name 'azurerm_network_security_groups'
+  desc 'Verifies settings for Network Security Groups'
+  example <<-EXAMPLE
+    azurerm_network_security_groups(resource_group: 'example') do
+      it{ should exist }
+    end
+  EXAMPLE
+
+  attr_reader :table
+
+  FilterTable.create
+             .add_accessor(:entries)
+             .add_accessor(:where)
+             .add(:exists?) { |obj| !obj.entries.empty? }
+             .add(:names, field: 'name')
+             .connect(self, :table)
+
+  def initialize(resource_group: nil)
+    resp = client.network_security_groups(resource_group)
+    return if resp.nil? || (resp.is_a?(Hash) && resp.key?('error'))
+
+    @table = resp
+  end
+
+  def to_s
+    'Network Security Groups'
+  end
+end

--- a/test/integration/verify/controls/azurerm_network_security_group.rb
+++ b/test/integration/verify/controls/azurerm_network_security_group.rb
@@ -2,8 +2,8 @@ resource_group = attribute('resource_group',            default: nil)
 nsg            = attribute('network_security_group',    default: nil)
 nsg_id         = attribute('network_security_group_id', default: nil)
 
-control 'azure_network_security_group' do
-  describe azure_network_security_group(resource_group: resource_group, name: nsg) do
+control 'azurerm_network_security_group' do
+  describe azurerm_network_security_group(resource_group: resource_group, name: nsg) do
     it                            { should exist }
     its('id')                     { should eq nsg_id }
     its('name')                   { should eq nsg }
@@ -14,11 +14,11 @@ control 'azure_network_security_group' do
     it                            { should_not allow_ssh_from_internet }
   end
 
-  describe azure_network_security_group(resource_group: resource_group, name: 'fake') do
+  describe azurerm_network_security_group(resource_group: resource_group, name: 'fake') do
     it { should_not exist }
   end
 
-  describe azure_network_security_group(resource_group: 'does-not-exist', name: nsg) do
+  describe azurerm_network_security_group(resource_group: 'does-not-exist', name: nsg) do
     it { should_not exist }
   end
 end

--- a/test/integration/verify/controls/azurerm_network_security_groups.rb
+++ b/test/integration/verify/controls/azurerm_network_security_groups.rb
@@ -1,7 +1,7 @@
 resource_group = attribute('resource_group', default: nil)
 
-control 'azure_network_security_groups' do
-  describe azure_network_security_groups(resource_group: resource_group) do
+control 'azurerm_network_security_groups' do
+  describe azurerm_network_security_groups(resource_group: resource_group) do
     it           { should exist }
     its('names') { should be_an(Array) }
   end


### PR DESCRIPTION
* Add deprecation warnings to azure_network_security_group(s)
* Update docs to reference new resource names
* Update integration tests to use renamed resources

Related #81 