### PR TITLE
Rename azure_monitor_activity_log_alert(s) resources to azurerm_monitor_activity_log_alert(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ end
 
 The following resources are available in the InSpec Azure Resource Pack
 
-- [azure_monitor_activity_log_alert](docs/resources/azure_monitor_activity_log_alert.md.erb)
-- [azure_monitor_activity_log_alerts](docs/resources/azure_monitor_activity_log_alerts.md.erb)
 - [azure_monitor_log_profile](docs/resources/azure_monitor_log_profile.md.erb)
 - [azure_monitor_log_profiles](docs/resources/azure_monitor_log_profiles.md.erb)
 - [azure_resource_groups](docs/resources/azure_resource_groups.md.erb)
 - [azure_security_center_policies](docs/resources/azure_security_center_policies.md.erb)
 - [azure_security_center_policy](docs/resources/azure_security_center_policy.md.erb)
+- [azurerm_monitor_activity_log_alert](docs/resources/azurerm_monitor_activity_log_alert.md.erb)
+- [azurerm_monitor_activity_log_alerts](docs/resources/azurerm_monitor_activity_log_alerts.md.erb)
 - [azurerm_network_security_group](docs/resources/azurerm_network_security_group.md.erb)
 - [azurerm_network_security_groups](docs/resources/azurerm_network_security_groups.md.erb)
 - [azurerm_network_watcher](docs/resources/azurerm_network_watcher.md.erb)

--- a/docs/resources/azurerm_monitor_activity_log_alert.md.erb
+++ b/docs/resources/azurerm_monitor_activity_log_alert.md.erb
@@ -1,21 +1,21 @@
 ---
-title: About the azure_monitor_activity_log_alert Resource
+title: About the azurerm_monitor_activity_log_alert Resource
 platform: azure
 ---
 
-# azure\_monitor\_activity\_log\_alert
+# azurerm\_monitor\_activity\_log\_alert
 
-Use the `azure_monitor_activity_log_alert` InSpec audit resource to test properties
+Use the `azurerm_monitor_activity_log_alert` InSpec audit resource to test properties
 of an Azure Monitor Activity Log Alert.
 
 <br />
 
 ## Syntax
 
-An `azure_monitor_activity_log_alert` resource block identifies an Activity Log Alert by
+An `azurerm_monitor_activity_log_alert` resource block identifies an Activity Log Alert by
 name and resource group.
 
-    describe azure_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
+    describe azurerm_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
       ...
     end
 <br />
@@ -24,13 +24,13 @@ name and resource group.
 
 ### Test that an example resource has an Activity Log Alert
 
-    describe azure_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
+    describe azurerm_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
       it { should exist }
     end
 
 ### Test an example resource has an Activity Log Alert with the correct operation
 
-    describe azure_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
+    describe azurerm_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
       its('operations') { should include 'Microsoft.Authorization/policyAssignments/write' }
     end
 
@@ -45,7 +45,7 @@ name and resource group.
 
 The resource group as well as the Activty Log Alert name.
 
-    describe azure_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
+    describe azurerm_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
       its('operations') { should include 'Microsoft.Authorization/policyAssignments/write' }
     end
 
@@ -69,12 +69,12 @@ of available matchers, please visit our [Universal Matchers page](https://www.in
 The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
 
     # If we expect 'AlertName' to always exist
-    describe azure_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
+    describe azurerm_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
       it { should exist }
     end
 
     # If we expect 'OtherAlertName' to never exist
-    describe azure_monitor_activity_log_alert(resource_group: 'example', name: 'OtherAlertName') do
+    describe azurerm_monitor_activity_log_alert(resource_group: 'example', name: 'OtherAlertName') do
       it { should_not exist }
     end
 

--- a/docs/resources/azurerm_monitor_activity_log_alerts.md.erb
+++ b/docs/resources/azurerm_monitor_activity_log_alerts.md.erb
@@ -1,20 +1,20 @@
 ---
-title: About the azure_monitor_activity_log_alerts Resource
+title: About the azurerm_monitor_activity_log_alerts Resource
 platform: azure
 ---
 
-# azure\_monitor\_activity\_log\_alerts
+# azurerm\_monitor\_activity\_log\_alerts
 
-Use the `azure_monitor_activity_log_alerts` InSpec audit resource to verify that an Activity Log
+Use the `azurerm_monitor_activity_log_alerts` InSpec audit resource to verify that an Activity Log
 Alert exists.
 
 <br />
 
 ## Syntax
 
-An `azure_monitor_activity_log_alerts` resource block identifies Activity Log Alerts by name.
+An `azurerm_monitor_activity_log_alerts` resource block identifies Activity Log Alerts by name.
 
-    describe azure_monitor_activity_log_alerts do
+    describe azurerm_monitor_activity_log_alerts do
       ...
     end
 <br />
@@ -23,7 +23,7 @@ An `azure_monitor_activity_log_alerts` resource block identifies Activity Log Al
 
 ### Test that an example resource has an Activity Log Alert
 
-    describe azure_monitor_activity_log_alerts do
+    describe azurerm_monitor_activity_log_alerts do
       its('names') { should include('ExampleLogAlert') }
     end
 
@@ -49,12 +49,12 @@ of available matchers, please visit our [Universal Matchers page](https://www.in
 The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
 
     # If we expect 'ExampleLogAlert' to exist
-    describe azure_monitor_activity_log_alerts do
+    describe azurerm_monitor_activity_log_alerts do
       it { should exist }
     end
 
     # If we do not expect 'ExampleLogAlert' to exist
-    describe azure_monitor_activity_log_alerts do
+    describe azurerm_monitor_activity_log_alerts do
       it { should_not exist }
     end
 

--- a/libraries/azure_monitor_activity_log_alert.rb
+++ b/libraries/azure_monitor_activity_log_alert.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'azurerm_resource'
+require 'azurerm_monitor_activity_log_alert'
 
-class AzureMonitorActivityLogAlert < AzurermResource
+class AzureMonitorActivityLogAlert < AzurermMonitorActivityLogAlert
   name 'azure_monitor_activity_log_alert'
-  desc 'Verifies settings for a Azure Monitor Activity Log Alert'
+  desc '[DEPRECATED] Please use the azurerm_monitor_activity_log_alert resource'
   example <<-EXAMPLE
     describe azure_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
       it { should exist }
@@ -12,44 +12,8 @@ class AzureMonitorActivityLogAlert < AzurermResource
     end
   EXAMPLE
 
-  ATTRS = {
-    name:       'name',
-    id:         'id',
-    conditions: 'conditionAllOf',
-    operations: 'operations',
-  }.freeze
-
-  attr_reader(*ATTRS.keys)
-
   def initialize(resource_group: nil, name: nil)
-    resp = client.activity_log_alert(resource_group, name)
-    return if resp.nil? || resp.key?('error')
-
-    @name       = resp['name']
-    @id         = resp['id']
-    @conditions = resp['properties']['condition']['allOf']
-    @operations = collect_operations(@conditions)
-
-    ATTRS.each do |attr_name, api_name|
-      next if instance_variable_defined?("@#{attr_name}")
-
-      instance_variable_set("@#{name}", fields[api_name])
-    end
-
-    @exists = true
-  end
-
-  def to_s
-    "#{name} Activity Log Alert"
-  end
-
-  private
-
-  # Collect all Operation strings for the Activity Log Alert
-  #
-  # @param [Hash] 'allOf' conditions from response properties
-  # @return [Array] of operation strings
-  def collect_operations(conditions)
-    conditions.find_all { |x| x['field'] == 'operationName' }.collect { |x| x['equals'] }
+    warn '[DEPRECATION] The `azure_monitor_activity_log_alert` resource is deprecated and will be removed in version 2.0. Use the `azurerm_monitor_activity_log_alert` resource instead.'
+    super
   end
 end

--- a/libraries/azure_monitor_activity_log_alerts.rb
+++ b/libraries/azure_monitor_activity_log_alerts.rb
@@ -1,53 +1,18 @@
 # frozen_string_literal: true
 
-require 'azurerm_resource'
+require 'azurerm_monitor_activity_log_alerts'
 
-class AzureMonitorActivityLogAlerts < AzurermResource
+class AzureMonitorActivityLogAlerts < AzurermMonitorActivityLogAlerts
   name 'azure_monitor_activity_log_alerts'
-  desc 'Verifies settings for Azure Monitor Activity Log Alerts'
+  desc '[DEPRECATED] Please use the azurerm_monitor_activity_log_alerts resource'
   example <<-EXAMPLE
     describe azure_monitor_activity_log_alerts do
       its('names') { should include('example-log-alert') }
     end
   EXAMPLE
 
-  attr_reader :table
-
-  FilterTable.create
-             .add_accessor(:entries)
-             .add_accessor(:where)
-             .add(:exists?) { |obj| !obj.entries.empty? }
-             .add(:names, field: 'name')
-             .add(:resource_group, field: 'resource_group')
-             .add(:operations, field: 'operations')
-             .connect(self, :table)
-
   def initialize
-    resp = client.activity_log_alerts
-    return if resp.nil? || (resp.is_a?(Hash) && resp.key?('error'))
-
-    @table = resp.collect(&with_resource_group)
-                 .collect(&with_operations)
-  end
-
-  def to_s
-    'Activity Log Alerts'
-  end
-
-  def with_resource_group
-    lambda do |group|
-      # Get resource group from ID string
-      name = group['id'].split('/')[4]
-      group.merge('resource_group' => name)
-    end
-  end
-
-  def with_operations
-    lambda do |alert|
-      conditions = alert.dig('properties', 'condition', 'allOf')
-      operations = conditions.find_all { |x| x['field'] == 'operationName' }.collect { |x| x['equals'] }
-
-      alert.merge('operations' => operations)
-    end
+    warn '[DEPRECATION] The `azure_monitor_activity_log_alerts` resource is deprecated and will be removed in version 2.0. Use the `azurerm_monitor_activity_log_alerts` resource instead.'
+    super
   end
 end

--- a/libraries/azurerm_monitor_activity_log_alert.rb
+++ b/libraries/azurerm_monitor_activity_log_alert.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'azurerm_resource'
+
+class AzurermMonitorActivityLogAlert < AzurermResource
+  name 'azurerm_monitor_activity_log_alert'
+  desc 'Verifies settings for a Azure Monitor Activity Log Alert'
+  example <<-EXAMPLE
+    describe azurerm_monitor_activity_log_alert(resource_group: 'example', name: 'AlertName') do
+      it { should exist }
+      its('operations') { should include 'Microsoft.Authorization/policyAssignments/write' }
+    end
+  EXAMPLE
+
+  ATTRS = {
+    name:       'name',
+    id:         'id',
+    conditions: 'conditionAllOf',
+    operations: 'operations',
+  }.freeze
+
+  attr_reader(*ATTRS.keys)
+
+  def initialize(resource_group: nil, name: nil)
+    resp = client.activity_log_alert(resource_group, name)
+    return if resp.nil? || resp.key?('error')
+
+    @name       = resp['name']
+    @id         = resp['id']
+    @conditions = resp['properties']['condition']['allOf']
+    @operations = collect_operations(@conditions)
+
+    ATTRS.each do |attr_name, api_name|
+      next if instance_variable_defined?("@#{attr_name}")
+
+      instance_variable_set("@#{name}", fields[api_name])
+    end
+
+    @exists = true
+  end
+
+  def to_s
+    "#{name} Activity Log Alert"
+  end
+
+  private
+
+  # Collect all Operation strings for the Activity Log Alert
+  #
+  # @param [Hash] 'allOf' conditions from response properties
+  # @return [Array] of operation strings
+  def collect_operations(conditions)
+    conditions.find_all { |x| x['field'] == 'operationName' }.collect { |x| x['equals'] }
+  end
+end

--- a/libraries/azurerm_monitor_activity_log_alerts.rb
+++ b/libraries/azurerm_monitor_activity_log_alerts.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'azurerm_resource'
+
+class AzurermMonitorActivityLogAlerts < AzurermResource
+  name 'azurerm_monitor_activity_log_alerts'
+  desc 'Verifies settings for Azure Monitor Activity Log Alerts'
+  example <<-EXAMPLE
+    describe azurerm_monitor_activity_log_alerts do
+      its('names') { should include('example-log-alert') }
+    end
+  EXAMPLE
+
+  attr_reader :table
+
+  FilterTable.create
+             .add_accessor(:entries)
+             .add_accessor(:where)
+             .add(:exists?) { |obj| !obj.entries.empty? }
+             .add(:names, field: 'name')
+             .add(:resource_group, field: 'resource_group')
+             .add(:operations, field: 'operations')
+             .connect(self, :table)
+
+  def initialize
+    resp = client.activity_log_alerts
+    return if resp.nil? || (resp.is_a?(Hash) && resp.key?('error'))
+
+    @table = resp.collect(&with_resource_group)
+                 .collect(&with_operations)
+  end
+
+  def to_s
+    'Activity Log Alerts'
+  end
+
+  def with_resource_group
+    lambda do |group|
+      # Get resource group from ID string
+      name = group['id'].split('/')[4]
+      group.merge('resource_group' => name)
+    end
+  end
+
+  def with_operations
+    lambda do |alert|
+      conditions = alert.dig('properties', 'condition', 'allOf')
+      operations = conditions.find_all { |x| x['field'] == 'operationName' }.collect { |x| x['equals'] }
+
+      alert.merge('operations' => operations)
+    end
+  end
+end

--- a/test/integration/verify/controls/azure_monitor_activity_log_alerts.rb
+++ b/test/integration/verify/controls/azure_monitor_activity_log_alerts.rb
@@ -1,5 +1,0 @@
-control 'azure_monitor_activity_log_alerts' do
-  describe azure_monitor_activity_log_alerts do
-    its('names') { should include('defaultLogAlert_5_3') }
-  end
-end

--- a/test/integration/verify/controls/azurerm_monitor_activity_log_alert.rb
+++ b/test/integration/verify/controls/azurerm_monitor_activity_log_alert.rb
@@ -14,15 +14,15 @@ alerts_and_operations = {
   '5_12' => 'Microsoft.Security/policies/write',
 }
 
-control 'azure_monitor_activity_log_alert' do
+control 'azurerm_monitor_activity_log_alert' do
   alerts_and_operations.each do |alert, operation|
-    describe azure_monitor_activity_log_alert(resource_group: resource_group, name: "#{log_alert_name}_#{alert}") do
+    describe azurerm_monitor_activity_log_alert(resource_group: resource_group, name: "#{log_alert_name}_#{alert}") do
       it                { should exist }
       its('operations') { should include operation }
     end
   end
 
-  describe azure_monitor_activity_log_alert(resource_group: resource_group, name: 'fake') do
+  describe azurerm_monitor_activity_log_alert(resource_group: resource_group, name: 'fake') do
     it { should_not exist }
   end
 end

--- a/test/integration/verify/controls/azurerm_monitor_activity_log_alerts.rb
+++ b/test/integration/verify/controls/azurerm_monitor_activity_log_alerts.rb
@@ -1,0 +1,5 @@
+control 'azurerm_monitor_activity_log_alerts' do
+  describe azurerm_monitor_activity_log_alerts do
+    its('names') { should include('defaultLogAlert_5_3') }
+  end
+end


### PR DESCRIPTION
* Add deprecation warnings to azure_monitor_activity_log_alert(s)
* Update docs to reference new resource names
* Update integration tests to use renamed resources

Related #81 