### PR TITLE
Rename azure{,rm}_resource_groups resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,16 @@ The following resources are available in the InSpec Azure Resource Pack
 - [azure_monitor_activity_log_alerts](docs/resources/azure_monitor_activity_log_alerts.md.erb)
 - [azure_monitor_log_profile](docs/resources/azure_monitor_log_profile.md.erb)
 - [azure_monitor_log_profiles](docs/resources/azure_monitor_log_profiles.md.erb)
-- [azure_resource_groups](docs/resources/azure_resource_groups.md.erb)
 - [azure_security_center_policies](docs/resources/azure_security_center_policies.md.erb)
 - [azure_security_center_policy](docs/resources/azure_security_center_policy.md.erb)
 - [azurerm_network_security_group](docs/resources/azurerm_network_security_group.md.erb)
 - [azurerm_network_security_groups](docs/resources/azurerm_network_security_groups.md.erb)
 - [azurerm_network_watcher](docs/resources/azurerm_network_watcher.md.erb)
 - [azurerm_network_watchers](docs/resources/azurerm_network_watchers.md.erb)
+- [azurerm_resource_groups](docs/resources/azurerm_resource_groups.md.erb)
 - [azurerm_virtual_machine](docs/resources/azurerm_virtual_machine.md.erb)
 - [azurerm_virtual_machine_disk](docs/resources/azurerm_virtual_machine_disk.md.erb)
 - [azurerm_virtual_machines](docs/resources/azurerm_virtual_machines.md.erb)
-
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -190,7 +190,7 @@ namespace :docs do
   desc 'Prints markdown links for resource doc files to update the README'
   task :resource_links do
     puts "\n"
-    Dir.entries('docs/resources')
+    Dir.entries('docs/resources').sort
        .select { |file| !File.directory?(file) }
        .collect { |file| "- [#{file.split('.')[0]}](docs/resources/#{file})" }
        .map { |link| puts link }

--- a/docs/resources/azurerm_resource_groups.md.erb
+++ b/docs/resources/azurerm_resource_groups.md.erb
@@ -1,11 +1,11 @@
 ---
-title: About the azure_resource_groups Resource
+title: About the azurerm_resource_groups Resource
 platform: azure
 ---
 
-# azure\_resource\_groups
+# azurerm\_resource\_groups
 
-Use the `azure_resource_groups` InSpec audit resource to test properties of
+Use the `azurerm_resource_groups` InSpec audit resource to test properties of
 some or all Azure Resource Groups
 
 A Resource Group is a grouping of Azure resources. This allows you to issue a
@@ -15,10 +15,10 @@ common command on a group of resources.
 
 ## Syntax
 
-An `azure_resource_groups` resource block uses an optional filter to select a
+An `azurerm_resource_groups` resource block uses an optional filter to select a
 group of Resource Groups and then tests that group.
 
-    describe azure_resource_groups do
+    describe azurerm_resource_groups do
       ...
     end
 
@@ -30,19 +30,19 @@ The following examples show how to use this InSpec audit resource.
 
 ### Check for a Resource Group
 
-    describe azure_resource_groups do
+    describe azurerm_resource_groups do
       its('names') { should include 'MyResourceGroup' }
     end
 
 ### Insist that your resource group exists
 
-    describe azure_resource_groups.where('name' => 'MyResourceGroup')
+    describe azurerm_resource_groups.where('name' => 'MyResourceGroup')
       it { should exist }
     end
 
 ### Use names to get all Virtual Machines in Azure
 
-    azure_resource_groups.names.each do |resource_group|
+    azurerm_resource_groups.names.each do |resource_group|
       describe azurerm_virtual_machines(resource_group: resource_group, name: 'MyVmName') do
         its('monitoring_agent_installed') { should be true }
       end
@@ -59,7 +59,7 @@ The following examples show how to use this InSpec audit resource.
 Filters the results to include only those resource groups that match the given
 name. This is a string value.
 
-    describe azure_resource_groups.where { name.start_with?('InSpec') } do
+    describe azurerm_resource_groups.where { name.start_with?('InSpec') } do
       it { should exist }
     end
 
@@ -84,7 +84,7 @@ page](https://www.inspec.io/docs/reference/matchers/).
 The control will pass if the filter returns at least one result. Use
 `should_not` if you expect zero matches.
 
-    describe azure_resource_groups do
+    describe azurerm_resource_groups do
       it { should exist }
     end
 

--- a/libraries/azure_resource_groups.rb
+++ b/libraries/azure_resource_groups.rb
@@ -1,28 +1,19 @@
 # frozen_string_literal: true
 
-require 'azurerm_resource'
+require 'azurerm_resource_groups'
 
-class AzureResourceGroups < AzurermResource
+class AzureResourceGroups < AzurermResourceGroups
   name 'azure_resource_groups'
-  desc 'Fetches all available resource groups'
+  desc '[DEPRECATED] Please use the azurerm_resource_groups resource'
   example <<-EXAMPLE
     describe azure_resource_groups do
       its('names') { should include('example-group') }
     end
   EXAMPLE
 
-  FilterTable.create
-             .add_accessor(:entries)
-             .add_accessor(:where)
-             .add(:exists?) { |obj| !obj.entries.empty? }
-             .add(:names, field: 'name')
-             .connect(self, :table)
-
-  def to_s
-    'Resource Groups'
-  end
-
-  def table
-    @table ||= client.resource_groups
+  def initialize
+    warn '[DEPRECATION] The `azure_resource_groups` resource is deprecated and will ' \
+         'be removed in version 2.0. Use the `azurerm_resource_groups` resource instead.'
+    super
   end
 end

--- a/libraries/azurerm_resource_groups.rb
+++ b/libraries/azurerm_resource_groups.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'azurerm_resource'
+
+class AzurermResourceGroups < AzurermResource
+  name 'azurerm_resource_groups'
+  desc 'Fetches all available resource groups'
+  example <<-EXAMPLE
+    describe azure_rmresource_groups do
+      its('names') { should include('example-group') }
+    end
+  EXAMPLE
+
+  FilterTable.create
+             .add_accessor(:entries)
+             .add_accessor(:where)
+             .add(:exists?) { |obj| !obj.entries.empty? }
+             .add(:names, field: 'name')
+             .connect(self, :table)
+
+  def to_s
+    'Resource Groups'
+  end
+
+  def table
+    @table ||= client.resource_groups
+  end
+end

--- a/test/integration/verify/controls/azure_resource_groups.rb
+++ b/test/integration/verify/controls/azure_resource_groups.rb
@@ -1,7 +1,7 @@
 resource_group = attribute('resource_group', default: nil)
 
-control 'azure_resource_groups' do
-  describe azure_resource_groups do
+control 'azurerm_resource_groups' do
+  describe azurerm_resource_groups do
     it           { should exist }
     its('names') { should include(resource_group) }
   end


### PR DESCRIPTION
Also added `sort` to the docs list generation because directory contents
are not otherwise ordered deterministically across platforms.

Signed-off-by: Trevor Bramble <tbramble@chef.io>