### PR TITLE
Rename azure_monitor_log_profile(s) resource to azurerm_monitor_log_profile(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,6 @@ end
 
 The following resources are available in the InSpec Azure Resource Pack
 
-- [azure_resource_groups](docs/resources/azure_resource_groups.md.erb)
-- [azure_security_center_policies](docs/resources/azure_security_center_policies.md.erb)
-- [azure_security_center_policy](docs/resources/azure_security_center_policy.md.erb)
 - [azurerm_monitor_activity_log_alert](docs/resources/azurerm_monitor_activity_log_alert.md.erb)
 - [azurerm_monitor_activity_log_alerts](docs/resources/azurerm_monitor_activity_log_alerts.md.erb)
 - [azurerm_monitor_log_profile](docs/resources/azurerm_monitor_log_profile.md.erb)

--- a/README.md
+++ b/README.md
@@ -76,10 +76,13 @@ end
 
 The following resources are available in the InSpec Azure Resource Pack
 
-- [azure_monitor_log_profile](docs/resources/azure_monitor_log_profile.md.erb)
-- [azure_monitor_log_profiles](docs/resources/azure_monitor_log_profiles.md.erb)
+- [azure_resource_groups](docs/resources/azure_resource_groups.md.erb)
+- [azure_security_center_policies](docs/resources/azure_security_center_policies.md.erb)
+- [azure_security_center_policy](docs/resources/azure_security_center_policy.md.erb)
 - [azurerm_monitor_activity_log_alert](docs/resources/azurerm_monitor_activity_log_alert.md.erb)
 - [azurerm_monitor_activity_log_alerts](docs/resources/azurerm_monitor_activity_log_alerts.md.erb)
+- [azurerm_monitor_log_profile](docs/resources/azurerm_monitor_log_profile.md.erb)
+- [azurerm_monitor_log_profiles](docs/resources/azurerm_monitor_log_profiles.md.erb)
 - [azurerm_network_security_group](docs/resources/azurerm_network_security_group.md.erb)
 - [azurerm_network_security_groups](docs/resources/azurerm_network_security_groups.md.erb)
 - [azurerm_network_watcher](docs/resources/azurerm_network_watcher.md.erb)

--- a/docs/resources/azurerm_monitor_log_profile.md.erb
+++ b/docs/resources/azurerm_monitor_log_profile.md.erb
@@ -1,20 +1,20 @@
 ---
-title: About the azure_monitor_log_profile Resource
+title: About the azurerm_monitor_log_profile Resource
 platform: azure
 ---
 
-# azure\_monitor\_log\_profile
+# azurerm\_monitor\_log\_profile
 
-Use the `azure_monitor_log_profile` InSpec audit resource to test properties
+Use the `azurerm_monitor_log_profile` InSpec audit resource to test properties
 of an Azure Monitor Log Profile.
 
 <br />
 
 ## Syntax
 
-An `azure_monitor_log_profile` resource block identifies a Log Profile by name.
+An `azurerm_monitor_log_profile` resource block identifies a Log Profile by name.
 
-    describe azure_monitor_log_profile(name: 'default') do
+    describe azurerm_monitor_log_profile(name: 'default') do
       ...
     end
 <br />
@@ -23,13 +23,13 @@ An `azure_monitor_log_profile` resource block identifies a Log Profile by name.
 
 ### Test that a Log Profile exists
 
-    describe azure_monitor_log_profile(name: 'default') do
+    describe azurerm_monitor_log_profile(name: 'default') do
       it { should exist }
     end
 
 ### Test that Log Profile retention is enabled
 
-    describe azure_monitor_log_profile(name: 'default') do
+    describe azurerm_monitor_log_profile(name: 'default') do
       its('retention_enabled') { should be true }
     end
 
@@ -43,7 +43,7 @@ An `azure_monitor_log_profile` resource block identifies a Log Profile by name.
 
 The name of the Log Profile.
 
-    describe azure_monitor_log_profile(name: 'default') do
+    describe azurerm_monitor_log_profile(name: 'default') do
       it { should exist }
     end
 
@@ -74,12 +74,12 @@ of available matchers, please visit our [Universal Matchers page](https://www.in
 The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
 
     #  If we expect 'default' to exist
-    describe azure_monitor_log_profile(name: 'default') do
+    describe azurerm_monitor_log_profile(name: 'default') do
       it { should exist }
     end
 
     # If we expect 'default' to not exist
-    describe azure_monitor_log_profile(name: 'default') do
+    describe azurerm_monitor_log_profile(name: 'default') do
       it { should_not exist }
     end
 

--- a/docs/resources/azurerm_monitor_log_profiles.md.erb
+++ b/docs/resources/azurerm_monitor_log_profiles.md.erb
@@ -1,19 +1,19 @@
 ---
-title: About the azure_monitor_log_profiles Resource
+title: About the azurerm_monitor_log_profiles Resource
 platform: azure
 ---
 
-# azure\_monitor\_log\_profiles
+# azurerm\_monitor\_log\_profiles
 
-Use the `azure_monitor_log_profiles` InSpec audit resource to verify that a Log Profile exists.
+Use the `azurerm_monitor_log_profiles` InSpec audit resource to verify that a Log Profile exists.
 
 <br />
 
 ## Syntax
 
-An `azure_monitor_log_profiles` resource block identifies a Log Profile by name.
+An `azurerm_monitor_log_profiles` resource block identifies a Log Profile by name.
 
-    describe azure_monitor_log_profiles do
+    describe azurerm_monitor_log_profiles do
       ...
     end
 <br />
@@ -22,7 +22,7 @@ An `azure_monitor_log_profiles` resource block identifies a Log Profile by name.
 
 ### Test that an example resource has a Log Profile
 
-    describe azure_monitor_log_profiles do
+    describe azurerm_monitor_log_profiles do
       its('names') { should include('ExampleProfile') }
     end
 
@@ -48,12 +48,12 @@ of available matchers, please visit our [Universal Matchers page](https://www.in
 The control will pass if the resource returns a result. Use `should_not` if you expect zero matches.
 
     # If we expect 'ExampleProfile' to exist
-    describe azure_monitor_log_profiles do
+    describe azurerm_monitor_log_profiles do
       its('names') { should include('ExampleProfile') }
     end
 
     # If we expect 'ExampleProfile' to not exist
-    describe azure_monitor_log_profiles do
+    describe azurerm_monitor_log_profiles do
       its('names') { should_not include('ExampleProfile') }
     end
 

--- a/libraries/azure_monitor_log_profile.rb
+++ b/libraries/azure_monitor_log_profile.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'azurerm_resource'
+require 'azurerm_monitor_log_profile'
 
-class AzureMonitorLogProfile < AzurermResource
+class AzureMonitorLogProfile < AzurermMonitorLogProfile
   name 'azure_monitor_log_profile'
-  desc 'Verifies settings for a Azure Monitor Log Profile'
+  desc '[DEPRECATED] Please uze azurerm_monitor_log_profile'
   example <<-EXAMPLE
     describe azure_monitor_log_profile(name: 'default') do
       it { should exist }
@@ -13,40 +13,8 @@ class AzureMonitorLogProfile < AzurermResource
     end
   EXAMPLE
 
-  ATTRS = {
-    name:              'name',
-    id:                'id',
-    retention_policy:  'retentionPolicy',
-    retention_days:    'retentionPolicyDays',
-    retention_enabled: 'retentionPolicyEnabled',
-  }.freeze
-
-  attr_reader(*ATTRS.keys)
-
   def initialize(options = { name: 'default' })
-    resp = client.log_profile(options[:name])
-    return if resp.nil? || resp.key?('error')
-
-    @name              = resp['name']
-    @id                = resp['id']
-    @retention_policy  = resp['properties']['retentionPolicy']
-    @retention_days    = resp['properties']['retentionPolicy']['days']
-    @retention_enabled = resp['properties']['retentionPolicy']['enabled']
-
-    ATTRS.each do |name, api_name|
-      next if instance_variable_defined?("@#{name}")
-
-      instance_variable_set("@#{name}", fields[api_name])
-    end
-
-    @exists = true
-  end
-
-  def has_log_retention_enabled?
-    !!retention_enabled
-  end
-
-  def to_s
-    "#{name} Log Profile"
+    warn '[DEPRECATION] The `azure_monitor_log_profile` resource is deprecated and will be removed in version 2.0. Use the `azurerm_monitor_log_profile` resource instead.'
+    super
   end
 end

--- a/libraries/azure_monitor_log_profiles.rb
+++ b/libraries/azure_monitor_log_profiles.rb
@@ -1,28 +1,18 @@
 # frozen_string_literal: true
 
-require 'azurerm_resource'
+require 'azurerm_monitor_log_profiles'
 
-class AzureMonitorLogProfiles < AzurermResource
+class AzureMonitorLogProfiles < AzurermMonitorLogProfiles
   name 'azure_monitor_log_profiles'
-  desc 'Fetches all Azure Monitor Log Profiles'
+  desc '[DEPRECATED] Please use azurerm_monitor_log_profiles'
   example <<-EXAMPLE
     describe azure_monitor_log_profiles do
       its('names') { should include('default') }
     end
   EXAMPLE
 
-  FilterTable.create
-             .add_accessor(:entries)
-             .add_accessor(:where)
-             .add(:exists?) { |obj| !obj.entries.empty? }
-             .add(:names, field: 'name')
-             .connect(self, :table)
-
-  def to_s
-    'Log Profiles'
-  end
-
-  def table
-    @table ||= client.log_profiles
+  def initialize
+    warn '[DEPRECATION] The `azure_monitor_log_profiles` resource is deprecated and will be removed in version 2.0. Use the `azurerm_monitor_log_profiles` resource instead.'
+    super
   end
 end

--- a/libraries/azurerm_monitor_log_profile.rb
+++ b/libraries/azurerm_monitor_log_profile.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'azurerm_resource'
+
+class AzurermMonitorLogProfile < AzurermResource
+  name 'azurerm_monitor_log_profile'
+  desc 'Verifies settings for a Azure Monitor Log Profile'
+  example <<-EXAMPLE
+    describe azurerm_monitor_log_profile(name: 'default') do
+      it { should exist }
+      its('retention_enabled') { should be true }
+      its('retention_days')    { should eq(365) }
+    end
+  EXAMPLE
+
+  ATTRS = {
+    name:              'name',
+    id:                'id',
+    retention_policy:  'retentionPolicy',
+    retention_days:    'retentionPolicyDays',
+    retention_enabled: 'retentionPolicyEnabled',
+  }.freeze
+
+  attr_reader(*ATTRS.keys)
+
+  def initialize(options = { name: 'default' })
+    resp = client.log_profile(options[:name])
+    return if resp.nil? || resp.key?('error')
+
+    @name              = resp['name']
+    @id                = resp['id']
+    @retention_policy  = resp['properties']['retentionPolicy']
+    @retention_days    = resp['properties']['retentionPolicy']['days']
+    @retention_enabled = resp['properties']['retentionPolicy']['enabled']
+
+    ATTRS.each do |name, api_name|
+      next if instance_variable_defined?("@#{name}")
+
+      instance_variable_set("@#{name}", fields[api_name])
+    end
+
+    @exists = true
+  end
+
+  def has_log_retention_enabled?
+    !!retention_enabled
+  end
+
+  def to_s
+    "#{name} Log Profile"
+  end
+end

--- a/libraries/azurerm_monitor_log_profiles.rb
+++ b/libraries/azurerm_monitor_log_profiles.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'azurerm_resource'
+
+class AzurermMonitorLogProfiles < AzurermResource
+  name 'azurerm_monitor_log_profiles'
+  desc 'Fetches all Azure Monitor Log Profiles'
+  example <<-EXAMPLE
+    describe azurerm_monitor_log_profiles do
+      its('names') { should include('default') }
+    end
+  EXAMPLE
+
+  FilterTable.create
+             .add_accessor(:entries)
+             .add_accessor(:where)
+             .add(:exists?) { |obj| !obj.entries.empty? }
+             .add(:names, field: 'name')
+             .connect(self, :table)
+
+  def to_s
+    'Log Profiles'
+  end
+
+  def table
+    @table ||= client.log_profiles
+  end
+end

--- a/test/integration/verify/controls/azure_monitor_log_profiles.rb
+++ b/test/integration/verify/controls/azure_monitor_log_profiles.rb
@@ -1,5 +1,0 @@
-control 'azure_monitor_activity_log_prolfiles' do
-  describe azure_monitor_log_profiles do
-    its('names') { should include('default') }
-  end
-end

--- a/test/integration/verify/controls/azurerm_monitor_log_profile.rb
+++ b/test/integration/verify/controls/azurerm_monitor_log_profile.rb
@@ -1,5 +1,5 @@
-control 'azure_monitor_activity_log_profile' do
-  describe azure_monitor_log_profile(name: 'default') do
+control 'azurerm_monitor_log_profile' do
+  describe azurerm_monitor_log_profile(name: 'default') do
     it { should exist }
     its('retention_enabled') { should be true }
     its('retention_days')    { should eq(365) }

--- a/test/integration/verify/controls/azurerm_monitor_log_profiles.rb
+++ b/test/integration/verify/controls/azurerm_monitor_log_profiles.rb
@@ -1,0 +1,5 @@
+control 'azurerm_monitor_log_profiles' do
+  describe azurerm_monitor_log_profiles do
+    its('names') { should include('default') }
+  end
+end


### PR DESCRIPTION
* Add deprecation warnings to azure_monitor_log_profile(s)
* Update docs to reference new resource names
* Update integration tests to use renamed resources

Related #81 