### PR TITLE
Introduces rake options task

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,38 @@ rake azure:login
 rake azure
 ```
 
+### Development
+
+To run all tests:
+```
+bundle
+rake
+```
+
+To run integration tests:
+```
+bundle
+rake test:integration
+```
+
+To run integration tests including a Network Watcher:
+```
+bundle
+rake network_watcher test:integration
+```
+
+To run a control called `azurerm_virtual_machine`:
+```
+bundle
+rake test:integration[azurerm_virtual_machine]
+```
+
+You may run multiple controls:
+```
+bundle
+rake test:integration[azure_resource_group,azurerm_virtual_machine]
+```
+
 ### Optional Components
 
 By default, rake tasks will only use core components. Optional components have
@@ -280,34 +312,3 @@ direnv allow # or source .envrc
 rake tf:apply
 ```
 
-### Development
-
-To run all tests:
-```
-bundle
-rake
-```
-
-To run integration tests:
-```
-bundle
-rake test:integration
-```
-
-To run integration tests including a Network Watcher:
-```
-bundle
-rake network_watcher test:integration
-```
-
-To run a control called `azurerm_virtual_machine`:
-```
-bundle
-rake test:integration[azurerm_virtual_machine]
-```
-
-You may run multiple controls:
-```
-bundle
-rake test:integration[azure_resource_group,azurerm_virtual_machine]
-```

--- a/README.md
+++ b/README.md
@@ -252,35 +252,6 @@ By default, rake tasks will only use core components. Optional components have
 associated integrations that will be skipped unless you enable these. We have
 the following optional pieces that may be managed with Terraform.
 
-Optional Components may be combined when running tasks:
-
-```
-rake options[option_1,option_2,option3]
-direnv allow # or source .envrc
-rake tf:apply
-```
-
-To disable optional components just re-run `rake options` without the components you wish to disable:
-
-```
-rake option[] # disable all optional components
-rake option[option_1] # enables option_1 disabling all other optional components
-```
-
-#### MSI Virtual Machine
-
-The MSI Virtual Machine may be used when testing the MSI Connector in Azure. To
-enable this component:
-
-```
-rake options[msi]
-direnv allow # or source .envrc
-rake tf:apply
-```
-
-In order to gain access to the Virtual Machine you may need to change firewall
-rules to enable an SSH connection from your host to the Virtual Machine.
-
 #### Network Watcher
 
 Network Watcher may be enabled to run integration tests related to the Network
@@ -312,3 +283,18 @@ direnv allow # or source .envrc
 rake tf:apply
 ```
 
+#### Using optional components
+
+Optional Components may be combined when running tasks:
+
+```
+rake options[option_1,option_2,option3]
+direnv allow # or source .envrc
+rake tf:apply
+```
+
+To disable optional components run `rake options[]` including only the optional components you wish to enable. Any omitted component will be disabled.
+```
+rake options[] # disable all optional components
+rake options[option_1] # enables option_1 disabling all other optional components
+```

--- a/README.md
+++ b/README.md
@@ -38,16 +38,6 @@ To create your account Service Principal Account:
 
 These must be stored in a environment variables prefaced with `AZURE_`.  If you use Dotenv then you may save these values in your own `.envrc` file. Either source it or run `direnv allow`. If you don't use Dotenv then you may just create environment variables in the way that your prefer.
 
-### Granting Azure Active Directory Read to Service Principal
-
-The Client/Active Directory Application you have configured Inspec Azure to use (`AZURE_CLIENT_ID`) must
-have permissions to read User data from the Azure Graph RBAC API.
-
-Please refer to the [Microsoft Documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications#updating-an-application)
-for information on how to grant these permissions to your application.
-
-Note: An Azure Administrator must grant your application these permissions.
-
 ### Use the Resources
 
 Since this is an InSpec resource pack, it only defines InSpec resources. To use these resources in your own controls you should create your own profile:
@@ -222,6 +212,72 @@ To start up an environment and run all tests:
 bundle
 rake azure:login
 rake azure
+```
+
+### Optional Components
+
+By default, rake tasks will only use core components. Optional components have
+associated integrations that will be skipped unless you enable these. We have
+the following optional pieces that may be managed with Terraform.
+
+Optional Components may be combined when running tasks:
+
+```
+rake options[option_1,option_2,option3]
+direnv allow # or source .envrc
+rake tf:apply
+```
+
+To disable optional components just re-run `rake options` without the components you wish to disable:
+
+```
+rake option[] # disable all optional components
+rake option[option_1] # enables option_1 disabling all other optional components
+```
+
+#### MSI Virtual Machine
+
+The MSI Virtual Machine may be used when testing the MSI Connector in Azure. To
+enable this component:
+
+```
+rake options[msi]
+direnv allow # or source .envrc
+rake tf:apply
+```
+
+In order to gain access to the Virtual Machine you may need to change firewall
+rules to enable an SSH connection from your host to the Virtual Machine.
+
+#### Network Watcher
+
+Network Watcher may be enabled to run integration tests related to the Network
+Watcher. We recommend leaving this disabled unless you are specifically working
+on related resources. You may only have one Network Watcher enabled per an
+Azure subscription at a time. To enable Network Watcher:
+
+```
+rake options[network_watcher]
+direnv allow # or source .envrc
+rake tf:apply
+```
+
+#### Graph API
+
+Graph API support may be enabled to test with `azure_ad` related resources.
+Graph requires granting "Active Directory Read" to the Service Principal. If
+your account does not have access leave this disabled.
+
+Please refer to the [Microsoft
+Documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-integrating-applications#updating-an-application)
+for information on how to grant these permissions to your application.
+
+Note: An Azure Administrator must grant your application these permissions.
+
+```
+rake options[graph]
+direnv allow # or source .envrc
+rake tf:apply
 ```
 
 ### Development

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ require 'open3'
 
 require_relative 'libraries/support/azure/credentials'
 require_relative 'lib/attribute_file_writer'
+require_relative 'lib/environment_file'
 
 RuboCop::RakeTask.new
 
@@ -86,10 +87,14 @@ namespace :inspec do
   end
 end
 
-desc 'This will enable network watcher creation and integration tests'
-task :network_watcher do
-  ENV['ENABLE_NETWORK_WATCHER'] = 'true'
-  ENV['TF_VAR_network_watcher_enabled'] = '1'
+desc 'Enables given optional components. See README for details.'
+task :options, :component do |t_, args|
+  components = []
+  components << args[:component] if args[:component]
+  components += args.extras unless args.extras.nil?
+
+  env_file = EnvironmentFile.new('.envrc')
+  env_file.synchronize(components)
 end
 
 task :setup_env do
@@ -98,6 +103,7 @@ task :setup_env do
   ENV['TF_VAR_tenant_id']       = credentials.tenant_id
   ENV['TF_VAR_client_id']       = credentials.client_id
   ENV['TF_VAR_client_secret']   = credentials.client_secret
+  ENV['TF_VAR_network_watcher'] = ENV.fetch('NETWORK_WATCHER', 'false')
 end
 
 task :check_env do
@@ -206,12 +212,14 @@ namespace :attributes do
   end
 
   task :write_guest_presence_to_file do
-    Dir.chdir(TERRAFORM_DIR) do
-      stdout, stderr, status = Open3.capture3("az ad user list --query=\"length([?userType == 'Guest'])\"")
+    if ENV['GRAPH']
+      Dir.chdir(TERRAFORM_DIR) do
+        stdout, stderr, status = Open3.capture3("az ad user list --query=\"length([?userType == 'Guest'])\"")
 
-      abort(stderr) unless status.success?
+        abort(stderr) unless status.success?
 
-      AttributeFileWriter.append(ENV['ATTRIBUTES_FILE'], "guest_accounts: #{stdout.to_i}")
+        AttributeFileWriter.append(ENV['ATTRIBUTES_FILE'], "guest_accounts: #{stdout.to_i}")
+      end
     end
   end
 end

--- a/lib/environment_file.rb
+++ b/lib/environment_file.rb
@@ -1,55 +1,89 @@
 class EnvironmentFile
-
   OPTIONS = %w{
     graph
     network_watcher
-  }
+  }.freeze
 
   def initialize(path)
     @file = File.new(path)
   end
 
-  def synchronize(envs)
-    to_delete = OPTIONS - envs
-    unknown = envs - OPTIONS
-
-    puts "The following options are not known #{unknown}. Please chose one of #{OPTIONS}." unless unknown.empty?
-
-    (envs - unknown).each{ |key| set_var(key.upcase, 'true') }
-    to_delete.each{ |key| remove_var(key.upcase) }
+  def current_options
+    OPTIONS.select { |option| key?(option.upcase) }
   end
 
-  def set_var(key, value)
-    found, new_content = replace_key(key, value) do |key, value|
-      "export #{key}=#{value}\n"
+  def synchronize(envs)
+    raise "The following options are unknown: #{unknown(envs)}. Please use only: #{OPTIONS.join(',')}." unless unknown(envs).empty?
+
+    add_vars(envs)
+    remove_vars(OPTIONS - envs)
+  end
+
+  private
+
+  def unknown(vars)
+    vars - OPTIONS
+  end
+
+  def add_vars(vars)
+    vars.each { |key| set_var(key.upcase) }
+  end
+
+  def remove_vars(vars)
+    vars.each { |key| remove_var(key.upcase) }
+  end
+
+  def match_export_statement(key, text)
+    /export #{key}=.*$/.match?(text)
+  end
+
+  def export_statement(key, value)
+    "export #{key}=#{value}\n"
+  end
+
+  def set_var(key, value = 'true')
+    found, new_content = replace_key(key, value) do |k, v|
+      export_statement(k, v)
     end
 
-    new_content << "export #{key}=#{value}\n" unless found
+    new_content << export_statement(key, value) unless found
 
     File.write(@file.path, new_content)
   end
 
   def remove_var(key)
-    _, new_content = replace_key(key, nil) do |_key, _value|
-      ""
+    _, new_content = replace_key(key) do |_key, _value|
+      ''
     end
 
     File.write(@file.path, new_content)
   end
 
-  def replace_key(key, value)
+  def key?(key)
+    File.open(@file.path, 'r').each_line do |line|
+      if match_export_statement(key, line)
+        return true
+      end
+    end
+
+    false
+  end
+
+  # rubocop:disable Performance/RedundantBlockCall
+  def replace_key(key, value = nil, &formatter)
     new_content = ''
-    found = false
+    found       = false
 
     File.open(@file.path, 'r').each_line do |line|
-      if line =~ /export #{key}=.*$/
-        new_content << yield(key, value)
+      if match_export_statement(key, line)
+        new_content << formatter.call(key, value)
         found = true
       else
         new_content << line
       end
     end
 
-    return found, new_content
+    [found, new_content]
   end
+  # rubocop:enable Performance/RedundantBlockCall
 end

--- a/lib/environment_file.rb
+++ b/lib/environment_file.rb
@@ -1,0 +1,55 @@
+class EnvironmentFile
+
+  OPTIONS = %w{
+    graph
+    network_watcher
+  }
+
+  def initialize(path)
+    @file = File.new(path)
+  end
+
+  def synchronize(envs)
+    to_delete = OPTIONS - envs
+    unknown = envs - OPTIONS
+
+    puts "The following options are not known #{unknown}. Please chose one of #{OPTIONS}." unless unknown.empty?
+
+    (envs - unknown).each{ |key| set_var(key.upcase, 'true') }
+    to_delete.each{ |key| remove_var(key.upcase) }
+  end
+
+  def set_var(key, value)
+    found, new_content = replace_key(key, value) do |key, value|
+      "export #{key}=#{value}\n"
+    end
+
+    new_content << "export #{key}=#{value}\n" unless found
+
+    File.write(@file.path, new_content)
+  end
+
+  def remove_var(key)
+    _, new_content = replace_key(key, nil) do |_key, _value|
+      ""
+    end
+
+    File.write(@file.path, new_content)
+  end
+
+  def replace_key(key, value)
+    new_content = ''
+    found = false
+
+    File.open(@file.path, 'r').each_line do |line|
+      if line =~ /export #{key}=.*$/
+        new_content << yield(key, value)
+        found = true
+      else
+        new_content << line
+      end
+    end
+
+    return found, new_content
+  end
+end

--- a/terraform/azure.tf
+++ b/terraform/azure.tf
@@ -34,7 +34,7 @@ resource "azurerm_resource_group" "rg" {
 
 resource "azurerm_network_watcher" "rg" {
   name                = "${azurerm_resource_group.rg.name}-netwatcher"
-  count               = "${var.network_watcher_enabled}"
+  count               = "${var.network_watcher}"
   location            = "${azurerm_resource_group.rg.location}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   tags {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -50,6 +50,6 @@ variable "unmanaged_data_disk_name" {
   default = "linux-internal-datadisk-1"
 }
 
-variable "network_watcher_enabled" {
+variable "network_watcher" {
   default = false
 }

--- a/test/integration/verify/controls/azurerm_ad_user.rb
+++ b/test/integration/verify/controls/azurerm_ad_user.rb
@@ -1,4 +1,6 @@
 control 'azurerm_ad_user' do
+  only_if { ENV['GRAPH'] }
+
   user_id = azurerm_ad_users.object_ids.first
   describe azurerm_ad_user(user_id: user_id) do
     it                    { should exist }

--- a/test/integration/verify/controls/azurerm_ad_users.rb
+++ b/test/integration/verify/controls/azurerm_ad_users.rb
@@ -1,6 +1,8 @@
 guest_accounts = attribute('guest_accounts', default: nil)
 
 control 'azurerm_ad_users' do
+  only_if { ENV['GRAPH'] }
+
   describe azurerm_ad_users do
     its('display_names')       { should_not be_empty }
     its('user_types')          { should_not be_empty }

--- a/test/integration/verify/controls/azurerm_network_watcher.rb
+++ b/test/integration/verify/controls/azurerm_network_watcher.rb
@@ -3,7 +3,7 @@ nw             = attribute('network_watcher_name', default: nil).first
 nw_id          = attribute('network_watcher_id',   default: nil).first
 
 control 'azurerm_network_watcher' do
-  only_if { ENV['ENABLE_NETWORK_WATCHER'] }
+  only_if { ENV['NETWORK_WATCHER'] }
 
   describe azurerm_network_watcher(resource_group: resource_group, name: nw) do
     it                        { should exist }

--- a/test/integration/verify/controls/azurerm_network_watchers.rb
+++ b/test/integration/verify/controls/azurerm_network_watchers.rb
@@ -1,7 +1,7 @@
 resource_group = attribute('resource_group', default: nil)
 
 control 'azurerm_network_watchers' do
-  only_if { ENV['ENABLE_NETWORK_WATCHER'] }
+  only_if { ENV['NETWORK_WATCHER'] }
 
   describe azurerm_network_watchers(resource_group: resource_group) do
     it           { should exist }

--- a/test/unit/lib/env_file_test.rb
+++ b/test/unit/lib/env_file_test.rb
@@ -1,0 +1,93 @@
+require 'tempfile'
+
+require_relative '../test_helper'
+require_relative '../../../lib/environment_file'
+
+describe EnvironmentFile do
+  before do
+    @tmp_file = Tempfile.new('env')
+    @content  = <<~CONTENT
+      unrelated content
+
+      export GRAPH=true
+
+      unrelated content
+
+      export NETWORK_WATCHER=true
+
+      unrelated content
+    CONTENT
+    @tmp_file.write @content
+    @tmp_file.close
+    @env_file = EnvironmentFile.new(@tmp_file.path)
+  end
+
+  after do
+    @tmp_file.unlink
+  end
+
+  describe 'synchronizing environment' do
+    it 'adds given keys and removes missing keys' do
+      @env_file.synchronize(['network_watcher'])
+
+      @tmp_file.open
+      @tmp_file.read.must_equal <<~CONTENT
+        unrelated content
+
+
+        unrelated content
+
+        export NETWORK_WATCHER=true
+
+        unrelated content
+      CONTENT
+    end
+
+    it 'warns and ignores unknown keys' do
+      @env_file.synchronize(['network_watcher', 'graph', 'unknown'])
+
+      @tmp_file.open
+      @tmp_file.read.must_equal @content
+    end
+  end
+
+  it 'leaves existing properties' do
+    @env_file.set_var('NETWORK_WATCHER', 'true')
+
+    @tmp_file.open
+    @tmp_file.read.must_equal @content
+  end
+
+  it 'removes a property' do
+    @env_file.remove_var('NETWORK_WATCHER')
+
+    @tmp_file.open
+    @tmp_file.read.must_equal <<~CONTENT
+      unrelated content
+
+      export GRAPH=true
+
+      unrelated content
+
+
+      unrelated content
+    CONTENT
+  end
+
+  it 'replaces property if the value is changes' do
+    @env_file.set_var('NETWORK_WATCHER', 'one')
+
+    @tmp_file.open
+    @tmp_file.read.must_equal <<~CONTENT
+      unrelated content
+
+      export GRAPH=true
+
+      unrelated content
+
+      export NETWORK_WATCHER=one
+
+      unrelated content
+    CONTENT
+  end
+end

--- a/test/unit/lib/env_file_test.rb
+++ b/test/unit/lib/env_file_test.rb
@@ -26,6 +26,18 @@ describe EnvironmentFile do
     @tmp_file.unlink
   end
 
+  describe 'current configuration' do
+    it 'gives the current options in file' do
+      @env_file.current_options.must_equal %w{graph network_watcher}
+    end
+
+    it 'gives empty list if not options in file' do
+      @env_file.synchronize([])
+
+      @env_file.current_options.must_equal []
+    end
+  end
+
   describe 'synchronizing environment' do
     it 'adds given keys and removes missing keys' do
       @env_file.synchronize(['network_watcher'])
@@ -43,51 +55,10 @@ describe EnvironmentFile do
       CONTENT
     end
 
-    it 'warns and ignores unknown keys' do
-      @env_file.synchronize(['network_watcher', 'graph', 'unknown'])
-
-      @tmp_file.open
-      @tmp_file.read.must_equal @content
+    it 'raises an error when unkown keys are given' do
+      assert_raises RuntimeError do
+        @env_file.synchronize(%w{network_watcher graph unknown})
+      end
     end
-  end
-
-  it 'leaves existing properties' do
-    @env_file.set_var('NETWORK_WATCHER', 'true')
-
-    @tmp_file.open
-    @tmp_file.read.must_equal @content
-  end
-
-  it 'removes a property' do
-    @env_file.remove_var('NETWORK_WATCHER')
-
-    @tmp_file.open
-    @tmp_file.read.must_equal <<~CONTENT
-      unrelated content
-
-      export GRAPH=true
-
-      unrelated content
-
-
-      unrelated content
-    CONTENT
-  end
-
-  it 'replaces property if the value is changes' do
-    @env_file.set_var('NETWORK_WATCHER', 'one')
-
-    @tmp_file.open
-    @tmp_file.read.must_equal <<~CONTENT
-      unrelated content
-
-      export GRAPH=true
-
-      unrelated content
-
-      export NETWORK_WATCHER=one
-
-      unrelated content
-    CONTENT
   end
 end


### PR DESCRIPTION
### Description

This change introduces a new rake task `options`. You may use this task to set optional components you wish to use. See the README for details on using this feature.

### Issues Resolved

fixes #99 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
