### PR TITLE
Fixes error where options weren't returned

### DIFF
--- a/lib/environment_file.rb
+++ b/lib/environment_file.rb
@@ -7,7 +7,7 @@ class EnvironmentFile
   def self.options(path)
     return [] unless File.readable?(path)
 
-    File.new(path).current_options
+    EnvironmentFile.new(path).current_options
   end
 
   def initialize(path)

--- a/test/unit/lib/env_file_test.rb
+++ b/test/unit/lib/env_file_test.rb
@@ -3,6 +3,7 @@ require 'tempfile'
 require_relative '../test_helper'
 require_relative '../../../lib/environment_file'
 
+# rubocop:disable Metrics/BlockLength
 describe EnvironmentFile do
   before do
     @tmp_file = Tempfile.new('env')
@@ -29,6 +30,12 @@ describe EnvironmentFile do
   describe 'no env file' do
     it 'returns no options' do
       assert_equal([], EnvironmentFile.options('fake/path'))
+    end
+  end
+
+  describe 'env file' do
+    it 'returns no options' do
+      assert_equal(%w{graph network_watcher}, EnvironmentFile.options(@tmp_file.path))
     end
   end
 
@@ -68,3 +75,4 @@ describe EnvironmentFile do
     end
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Signed-off-by: David McCown <dmccown@chef.io>

### Description

Fixes a bug where the options weren't being returned on rake commands.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
