### PR TITLE
Adds Ruairi as a code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Global owners
 *       @chef/dca-team
+*       @r-fennell

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,3 +26,4 @@ To mention the team, use @chef/dca-team
  * [Joshua Padgett](https://github.com/Padgett)
  * [Paul Welch](https://github.com/pwelch)
  * [Trevor Bramble](https://github.com/TrevorBramble)
+ * [Rauiri Fennell](https://github.com/r-fennell)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -25,5 +25,5 @@ To mention the team, use @chef/dca-team
 
  * [Joshua Padgett](https://github.com/Padgett)
  * [Paul Welch](https://github.com/pwelch)
- * [Trevor Bramble](https://github.com/TrevorBramble)
  * [Ruairi Fennell](https://github.com/r-fennell)
+ * [Trevor Bramble](https://github.com/TrevorBramble)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,4 +26,4 @@ To mention the team, use @chef/dca-team
  * [Joshua Padgett](https://github.com/Padgett)
  * [Paul Welch](https://github.com/pwelch)
  * [Trevor Bramble](https://github.com/TrevorBramble)
- * [Rauiri Fennell](https://github.com/r-fennell)
+ * [Ruairi Fennell](https://github.com/r-fennell)


### PR DESCRIPTION
Signed-off-by: David McCown <dmccown@chef.io>

### Description

Adds Ruairi as a code owner

### Check List

- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
