### PR TITLE
Add pricing_tier field

### DIFF
--- a/docs/resources/azurerm_security_center_policy.md.erb
+++ b/docs/resources/azurerm_security_center_policy.md.erb
@@ -90,7 +90,7 @@ will search for the `default` Security Center Policy (Optional).
     `next_generation_firewall`, `vulnerability_assessment`, `just_in_time_network_access`,
     `app_whitelisting`, `sql_auditing`, `sql_transparent_data_encryption`,
     `notifications_enabled`, `send_security_email_to_admin`, `contact_emails`,
-    `contact_phone`
+    `contact_phone`, `pricing_tier`
 
 ### id
 
@@ -110,6 +110,12 @@ The name of the Security Center Policy.
 Log collection indicates if the monitoring agent will collect security data (`On`|`Off`).
 
     its('log_collection') { should eq('On') }
+
+### pricing\_tier
+
+Cost/Feature Model under which the subscription is operating (`Standard`|`Free`).
+
+    its('pricing_tier') { should eq('Standard') }
 
 ### patch
 

--- a/libraries/azurerm_security_center_policy.rb
+++ b/libraries/azurerm_security_center_policy.rb
@@ -15,6 +15,7 @@ class AzurermSecurityCenterPolicy < AzurermSingularResource
     name:                            'name',
     id:                              'id',
     log_collection:                  'logCollection',
+    pricing_tier:                    'selectedPricingTier',
     patch:                           'patch',
     baseline:                        'baseline',
     anti_malware:                    'antimalware',
@@ -43,6 +44,7 @@ class AzurermSecurityCenterPolicy < AzurermSingularResource
     @name = resp['name']
     @id   = resp['id']
     @log_collection = resp['properties']['logCollection']
+    @pricing_tier   = resp['properties']['pricingConfiguration']['selectedPricingTier']
 
     fields = resp['properties']['recommendations'].merge(
       resp['properties']['securityContactConfiguration'],

--- a/test/integration/verify/controls/azure_security_center_policy.rb
+++ b/test/integration/verify/controls/azure_security_center_policy.rb
@@ -17,6 +17,7 @@ control 'azurerm_security_center_policy' do
     its('id')                              { should eq("/subscriptions/#{ENV['AZURE_SUBSCRIPTION_ID']}/providers/Microsoft.Security/policies/default") }
     its('name')                            { should eq('default') }
     its('log_collection')                  { should eq('On').or eq('Off') }
+    its('pricing_tier')                    { should eq('Standard').or eq('Free') }
     its('patch')                           { should eq('On').or eq('Off') }
     its('baseline')                        { should eq('On').or eq('Off') }
     its('anti_malware')                    { should eq('On').or eq('Off') }


### PR DESCRIPTION
for control 6.2

### Description

Adding field priving_tier to azurerm_security_poilicy resource

### Issues Resolved

Able to test control 6.2 of cis benchmark

### Check List

- [ x] New functionality includes tests
- [ x] All tests pass
- [ x] `rake lint` passes
- [ x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
