### PR TITLE
Adds SQL Administrators, always request JSON from Azure

### DIFF
--- a/libraries/azurerm_sql_server.rb
+++ b/libraries/azurerm_sql_server.rb
@@ -42,6 +42,10 @@ class AzurermSqlServer < AzurermSingularResource
     management.sql_server_threat_detection_settings(@resource_group, @server_name)
   end
 
+  def administrators
+    management.sql_server_administrators(@resource_group, @server_name)
+  end
+
   def to_s
     "Azure SQL Server: '#{name}'"
   end

--- a/libraries/support/azure/management.rb
+++ b/libraries/support/azure/management.rb
@@ -189,6 +189,14 @@ module Azure
       )
     end
 
+    def sql_server_administrators(resource_group, server_name)
+      get(
+        url: link(location: "Microsoft.Sql/servers/#{server_name}/administrators",
+                  resource_group: resource_group),
+        api_version: '2014-04-01',
+      )
+    end
+
     private
 
     def link(location:, provider: true, resource_group: nil)

--- a/libraries/support/azure/service.rb
+++ b/libraries/support/azure/service.rb
@@ -73,7 +73,9 @@ module Azure
       confirm_configured!
 
       cache.fetch(url) do
-        body = rest_client.get(url, params: { 'api-version' => api_version }).body
+        body = rest_client.get(url,
+                               params: { 'api-version' => api_version },
+                               headers: {:Accept => 'application/json'}).body
 
         error_handler&.(body)
 

--- a/libraries/support/azure/service.rb
+++ b/libraries/support/azure/service.rb
@@ -75,7 +75,7 @@ module Azure
       cache.fetch(url) do
         body = rest_client.get(url,
                                params: { 'api-version' => api_version },
-                               headers: {:Accept => 'application/json'}).body
+                               headers: { Accept: 'application/json' }).body
 
         error_handler&.(body)
 


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

### Description

- Adds endpoint for retrieving SQL Server Administrators from Azure.
- Adds header to REST calls explicitly requesting JSON response, as [some endpoints may return XML](https://github.com/MicrosoftDocs/feedback/issues/662)

### Check List

- [N/A] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
