### PR TITLE
Exempts tags from being turned into a struct

### DIFF
--- a/libraries/support/azure/service.rb
+++ b/libraries/support/azure/service.rb
@@ -14,6 +14,11 @@ module Azure
       end
     end
 
+    EXEMPTED_TAGS = %i(
+      tags
+    ).freeze
+    private_constant :EXEMPTED_TAGS
+
     def with_cache(cache)
       @cache = cache
     end
@@ -42,7 +47,11 @@ module Azure
       return data unless data.is_a?(Hash)
       return data if data.empty?
 
-      ResponseStruct.create(data.keys.map(&:to_sym), data.values.map { |v| to_struct(v) })
+      exempted = data.slice(*EXEMPTED_TAGS)
+      data.reject! { |k, _| EXEMPTED_TAGS.include?(k.to_sym) }
+
+      ResponseStruct.create(data.keys.map(&:to_sym) + exempted.keys.map(&:to_sym),
+                            data.values.map { |v| to_struct(v) } + exempted.values)
     end
 
     private

--- a/test/unit/support/azure/service_test.rb
+++ b/test/unit/support/azure/service_test.rb
@@ -3,8 +3,10 @@ require_relative '../../../../libraries/support/azure/service'
 
 describe Azure::Service do
   let(:address)         { { street: '123 Fake St.', city: 'Nowhere', state: 'NO' } }
+  let(:tags)            { { 'tag-1' => 'my-custom-tag', 'tag-2' => 'my-other-tag' } }
   let(:john)            { { name: 'John', age: 20, address: address } }
   let(:jane)            { { name: 'Jane', age: 25, address: {} } }
+  let(:doe)             { { name: 'Doe', age: 30, address: {}, tags: tags } }
   let(:array_of_hashes) { [john, jane] }
 
   before do
@@ -36,5 +38,11 @@ describe Azure::Service do
     assert_equal('Jane', struct.name)
     assert_equal(25, struct.age)
     assert_equal({}, struct.address)
+  end
+
+  it 'preserves tags key' do
+    struct = @service.to_struct(doe)
+
+    assert_equal(tags, struct.tags)
   end
 end


### PR DESCRIPTION
Turning tags into a struct makes it difficult to compare the expected
sets of tags with the actual set of tags returned. There's also the
potential for dashes in tag names. In these cases the struct methods
are only accessable by calling `send` on the struct with the key names.

This change preserves tags as a hash.

fixes #138

Signed-off-by: David McCown <dmccown@chef.io>

### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec](https://github.com/inspec/inspec-azure/CONTRIBUTING.MD) document before submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
