### PR TITLE
Scopes storage_accounts resource by resource group

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -65,13 +65,6 @@ task :check_attributes_file do
 end
 
 namespace :inspec do
-  desc 'Runs profile against Azure with given Subscription Id'
-  task :run, [:subscription_id] => :check_attributes_file do |_t, args|
-    sh('./bin/inspec', 'exec', '.',
-       '--attrs', "terraform/#{ENV['ATTRIBUTES_FILE']}",
-       '-t', "azure://#{args[:subscription_id]}")
-  end
-
   desc 'InSpec syntax check'
   task :check do
     stdout, status = Open3.capture2('./bin/inspec check .')

--- a/libraries/azurerm_storage_accounts.rb
+++ b/libraries/azurerm_storage_accounts.rb
@@ -17,8 +17,8 @@ class StorageAccounts < AzurermPluralResource
 
   attr_reader :table
 
-  def initialize
-    resp = management.storage_accounts
+  def initialize(resource_group: nil)
+    resp = management.storage_accounts(resource_group)
     return if has_error?(resp)
 
     @table = resp

--- a/libraries/support/azure/management.rb
+++ b/libraries/support/azure/management.rb
@@ -102,9 +102,10 @@ module Azure
       )
     end
 
-    def storage_accounts
+    def storage_accounts(resource_group)
       get(
-        url: link(location: 'Microsoft.Storage/storageAccounts'),
+        url: link(location: 'Microsoft.Storage/storageAccounts',
+                  resource_group: resource_group),
         api_version: '2017-06-01',
       )
     end

--- a/test/integration/verify/controls/azurerm_storage_accounts.rb
+++ b/test/integration/verify/controls/azurerm_storage_accounts.rb
@@ -1,7 +1,12 @@
+resource_group = attribute('resource_group', default: nil)
 storage_account = attribute('storage_account', default: nil)
 
 control 'azurerm_storage_accounts' do
   describe azurerm_storage_accounts do
+    its('names') { should include(storage_account) }
+  end
+
+  describe azurerm_storage_accounts(resource_group: resource_group) do
     its('names') { should include(storage_account) }
   end
 end

--- a/test/integration/verify/controls/azurerm_storage_accounts.rb
+++ b/test/integration/verify/controls/azurerm_storage_accounts.rb
@@ -1,4 +1,4 @@
-resource_group = attribute('resource_group', default: nil)
+resource_group  = attribute('resource_group',  default: nil)
 storage_account = attribute('storage_account', default: nil)
 
 control 'azurerm_storage_accounts' do


### PR DESCRIPTION
### Description

When trying to iterate over all resource groups and storage accounts we
currently can only ask for all storage accounts. This means we try to
look up every storage account for every resource group.

This fix allows one to scope their storage accounts query by resource
group.

Removes rake target we no longer need.

Signed-off-by: David McCown <dmccown@chef.io>

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
