### PR TITLE
Add Storage Account access key regeneration check

### DIFF
--- a/libraries/azurerm_storage_account.rb
+++ b/libraries/azurerm_storage_account.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'azurerm_resource'
+require 'date'
+require 'time'
 
 class AzurermStorageAccout < AzurermSingularResource
   name 'azurerm_storage_account'
@@ -21,17 +23,36 @@ class AzurermStorageAccout < AzurermSingularResource
   attr_reader(*ATTRS)
 
   def initialize(name: 'default', resource_group: nil)
-    resp = management.storage_account(resource_group, name)
-    return if has_error?(resp)
+    storage_account = management.storage_account(resource_group, name)
+    return if has_error?(storage_account)
 
-    @name       = resp.name
-    @id         = resp.id
-    @properties = resp.properties
+    assign_fields(ATTRS, storage_account)
 
     @exists = true
   end
 
+  def have_recently_generated_access_key
+    now = DateTime.now
+    less_than = to_utc(now)
+    greater_than = to_utc(now-90)
+
+    filter = "resourceId eq '#{id}' and "\
+             "eventTimestamp ge '#{greater_than}' and "\
+             "eventTimestamp le '#{less_than}' and "\
+             "operations eq 'Microsoft.Storage/storageAccounts/regeneratekey/action'"
+
+    log_events = management.activity_log_alert_filtered(filter)
+    log_events.any?
+  end
+
   def to_s
     "#{name} Storage Account"
+  end
+
+  private
+
+  def to_utc(datetime)
+    # API requires times in UTC ISO8601 format.
+    datetime.to_time.utc.iso8601
   end
 end

--- a/libraries/support/azure/management.rb
+++ b/libraries/support/azure/management.rb
@@ -27,6 +27,13 @@ module Azure
       )
     end
 
+    def activity_log_alert_filtered(filter)
+      get(
+        url: link(location: "Microsoft.Insights/eventTypes/management/values/?$filter=#{filter}"),
+        api_version: '2017-03-01-preview',
+      )
+    end
+
     def log_profile(id)
       get(
         url: link(location: 'Microsoft.Insights/logProfiles') + id,


### PR DESCRIPTION
### Description

Adds the ability for an `azurerm_storage_account` to check if its Access Key(s) have been regenerated in the last 90 days.

### Check List

- [N/A] New functionality includes tests
- [x] All tests pass
- [ ] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Ruairi Fennell <rfennell@chef.io>