### PR TITLE
Add a missing word in documentation boilerplate

### DIFF
--- a/docs/resources/azurerm_ad_user.md.erb
+++ b/docs/resources/azurerm_ad_user.md.erb
@@ -218,7 +218,7 @@ its('provisionedPlants.first.provisioningStatus') { should eq "Success" }
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.

--- a/docs/resources/azurerm_key_vault.md.erb
+++ b/docs/resources/azurerm_key_vault.md.erb
@@ -107,7 +107,7 @@ dots (`.`).
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.

--- a/docs/resources/azurerm_monitor_activity_log_alert.md.erb
+++ b/docs/resources/azurerm_monitor_activity_log_alert.md.erb
@@ -134,7 +134,7 @@ dots (`.`).
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.

--- a/docs/resources/azurerm_monitor_log_profile.md.erb
+++ b/docs/resources/azurerm_monitor_log_profile.md.erb
@@ -99,7 +99,7 @@ dots (`.`).
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.

--- a/docs/resources/azurerm_network_security_group.md.erb
+++ b/docs/resources/azurerm_network_security_group.md.erb
@@ -120,7 +120,7 @@ dots (`.`).
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.

--- a/docs/resources/azurerm_network_watcher.md.erb
+++ b/docs/resources/azurerm_network_watcher.md.erb
@@ -94,7 +94,7 @@ dots (`.`).
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.

--- a/docs/resources/azurerm_security_center_policy.md.erb
+++ b/docs/resources/azurerm_security_center_policy.md.erb
@@ -264,7 +264,7 @@ dots (`.`).
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.

--- a/docs/resources/azurerm_sql_database.md.erb
+++ b/docs/resources/azurerm_sql_database.md.erb
@@ -110,7 +110,7 @@ dots (`.`).
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.

--- a/docs/resources/azurerm_sql_server.md.erb
+++ b/docs/resources/azurerm_sql_server.md.erb
@@ -109,7 +109,7 @@ dots (`.`).
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.

--- a/docs/resources/azurerm_subnet.md.erb
+++ b/docs/resources/azurerm_subnet.md.erb
@@ -151,7 +151,7 @@ dots (`.`).
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.

--- a/docs/resources/azurerm_virtual_machine.md.erb
+++ b/docs/resources/azurerm_virtual_machine.md.erb
@@ -181,7 +181,7 @@ dots (`.`).
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.

--- a/docs/resources/azurerm_virtual_machine_disk.md.erb
+++ b/docs/resources/azurerm_virtual_machine_disk.md.erb
@@ -158,7 +158,7 @@ dots (`.`).
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.

--- a/docs/resources/azurerm_virtual_network.md.erb
+++ b/docs/resources/azurerm_virtual_network.md.erb
@@ -187,7 +187,7 @@ dots (`.`).
 
 The API may not always return keys that do not have any associated data. There
 may be cases where the deeply nested property may not have the desired
-attribute along your call chain. If find yourself writing tests against
+attribute along your call chain. If you find yourself writing tests against
 properties that may be nil, fork this resource pack and add an accessor to the
 resource. Within that accessor you'll be able to guard against nil keys. Pull
 requests are always welcome.


### PR DESCRIPTION
### Description

There was a missing word in our boilerplate documentation. Now there is not.

### Check List

- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
