### PR TITLE
Add graceful-ish handling of missing response data

### DIFF
--- a/libraries/support/azure/response_struct.rb
+++ b/libraries/support/azure/response_struct.rb
@@ -7,8 +7,13 @@ module Azure
         def key?(key)
           members.include?(key)
         end
-
         alias_method :keys, :members
+
+        private
+
+        def method_missing(_name)
+          nil
+        end
       end.new(*values)
     end
   end

--- a/test/unit/support/azure/response_struct_test.rb
+++ b/test/unit/support/azure/response_struct_test.rb
@@ -1,0 +1,43 @@
+require_relative '../../test_helper'
+require_relative '../../../../libraries/support/azure/response_struct'
+
+describe Azure::ResponseStruct do
+  let(:keys) { %i(foo bar baz) }
+  let(:values) { %w{foo bar baz} }
+  let(:data) { keys.zip(values).to_h }
+
+  subject { Azure::ResponseStruct.create(keys, values) }
+
+  it 'should produce a Struct' do
+    expect(subject).must_be_kind_of Struct
+  end
+
+  it 'should respond to given keys' do
+    keys.map { |key| expect(subject).must_respond_to key }
+  end
+
+  it 'should have expected values for given keys' do
+    data.map { |key, value| expect(subject.send(key)).must_equal value }
+  end
+
+  it 'should return nil for unknown keys' do
+    expect(subject.unknown_key).must_be_nil
+  end
+
+  describe 'should support some Hash methods' do
+    it 'should support .key?()' do
+      expect(subject).must_respond_to :key?
+
+      expect(subject.key?(keys.first)).must_equal true
+      expect(subject.key?(:unknown_key)).must_equal false
+    end
+
+    it 'should support .keys()' do
+      expect(subject).must_respond_to :keys
+
+      expect(subject.keys).must_equal keys
+
+      expect(subject.keys).must_equal subject.members
+    end
+  end
+end


### PR DESCRIPTION
### Description

This is more scar tissue around Azure APIs not adhering to a response contract such that the key for a given item is not returned when there is no attached item of that type. (If a VM has no attached drives, it does not return `{... "drives": [] ...}`, it just does not include that element at all.)

When testing against our struct data with dot-notation instead of hash index references (`data.foo` vs. `data[:foo]`) a `NoMethodError` exception would be raised if `foo` wasn't included in the API response.

This change handles that scenario by returning `nil` when there is a reference to an unkown key. It's not ideal, but it'll help while we get more feedback from our current model and decide whether a larger change is appropriate.

### Check List

- [X] New functionality includes tests
- [X] All tests pass
- [X] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
