### PR TITLE
Remove SSH from environment requirements

### DIFF
--- a/.envrc-example
+++ b/.envrc-example
@@ -5,5 +5,3 @@ export AZURE_SUBSCRIPTION_ID=
 export AZURE_CLIENT_ID=
 export AZURE_TENANT_ID=
 export AZURE_CLIENT_SECRET=
-
-export SSH_KEY=

--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ export AZURE_SUBSCRIPTION_ID=<subscription id>
 export AZURE_CLIENT_ID=<client id>
 export AZURE_TENANT_ID=<tenant id>
 export AZURE_CLIENT_SECRET=<client secret>
-export SSH_KEY=<ssh-rsa...>
 ```
 
 For PowerShell, set the following environment variables
@@ -159,10 +158,7 @@ $env:AZURE_SUBSCRIPTION_ID="<subscription id>"
 $env:AZURE_CLIENT_ID="<client id>"
 $env:AZURE_CLIENT_SECRET="<tenant id>"
 $env:AZURE_TENANT_ID="<client secret>"
-$env:SSH_KEY="<ssh-rsa...>"
 ```
-
-> NOTE: The the SSH_KEY is used in the Terraform plan to create an AKS cluster. It is the public SSH key used to access the cluster. It's not actually used; however, it's a required parameter for creating a new cluster.
 
 **Setup Azure CLI**
 - Follow the instructions for your platform [here](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)

--- a/Rakefile
+++ b/Rakefile
@@ -110,7 +110,6 @@ task :setup_env do
   ENV['TF_VAR_tenant_id']       = ENV['AZURE_TENANT_ID']
   ENV['TF_VAR_client_id']       = ENV['AZURE_CLIENT_ID']
   ENV['TF_VAR_client_secret']   = ENV['AZURE_CLIENT_SECRET']
-  ENV['TF_VAR_ssh_key']         = ENV['SSH_KEY']
   ENV['TF_VAR_public_vm_count'] = '1' if ENV.key?('MSI')
 end
 

--- a/terraform/azure.tf
+++ b/terraform/azure.tf
@@ -635,6 +635,11 @@ resource "azurerm_sql_database" "sql-database" {
   tags {}
 }
 
+resource "tls_private_key" "key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
 resource "azurerm_kubernetes_cluster" "test" {
   name                = "inspecakstest"
   location            = "${azurerm_resource_group.rg.location}"
@@ -652,7 +657,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     admin_username = "inspecuser1"
 
     ssh_key {
-      key_data = "${var.ssh_key}"
+      key_data = "${tls_private_key.key.public_key_openssh}"
     }
   }
   service_principal {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -2,7 +2,6 @@ variable "subscription_id" {}
 variable "client_id" {}
 variable "client_secret" {}
 variable "tenant_id" {}
-variable "ssh_key" {}
 
 variable "location" {
   default = "East US"


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

### Description

Currently an SSH key must be provided in the environment for the creation of a Kubernetes cluster. This SSH key is not needed for the integration tests and therefor is not required to be persistent. We can instead randomly generate the SSH key via Terraform.

### Check List

- [NA] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
