### PR TITLE
Aks control fix

### DIFF
--- a/test/integration/verify/controls/azurerm_aks_cluster.rb
+++ b/test/integration/verify/controls/azurerm_aks_cluster.rb
@@ -16,6 +16,7 @@ control 'azurerm_aks_cluster' do
     its('properties.agentPoolProfiles.first.storageProfile') { should cmp 'ManagedDisks' }
     its('properties.agentPoolProfiles.first.maxPods')        { should cmp '110' }
     its('properties.agentPoolProfiles.first.osType')         { should cmp 'Linux' }
+    its('properties.kubernetesVersion')                      { should_not be nil }
   end
 
   describe azurerm_aks_cluster(resource_group: resource_group, name: 'fake') do

--- a/test/integration/verify/controls/azurerm_aks_cluster.rb
+++ b/test/integration/verify/controls/azurerm_aks_cluster.rb
@@ -7,7 +7,6 @@ control 'azurerm_aks_cluster' do
     its('name')                                              { should cmp 'inspecakstest' }
     its('type')                                              { should cmp 'Microsoft.ContainerService/managedClusters' }
     its('properties.provisioningState')                      { should cmp 'Succeeded' }
-    its('properties.kubernetesVersion')                      { should cmp '1.9.11' }
     its('properties.dnsPrefix')                              { should cmp 'inspecaksagent1' }
     its('properties.fqdn')                                   { should cmp cluster_fqdn }
     its('properties.agentPoolProfiles.first.name')           { should cmp 'inspecaks' }


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

### Description

Our current integration tests check for a specific Kubernetes version for an `azurerm_aks_cluster`, however we do not specify a specific version to use in the Terraform plan. Default TF resource behaviour is to use the latest stable release. I'd rather this than pin to an old version. This PR prefers checking that the version is set.

### Issues Resolved

CI issues when K8 version bumps.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
