### PR TITLE
Remove broken policy check

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,11 +57,6 @@ task :syntax do
   end
 end
 
-task :check_attributes_file do
-  abort('$ATTRIBUTES_FILE not set. Please source .envrc.') if ENV['ATTRIBUTES_FILE'].nil?
-  abort('$ATTRIBUTES_FILE has no content. Check .envrc.') if ENV['ATTRIBUTES_FILE'].empty?
-end
-
 namespace :inspec do
   desc 'InSpec syntax check'
   task :check do
@@ -126,7 +121,7 @@ namespace :test do
     t.test_files = FileList['test/unit/**/*_test.rb']
   end
 
-  task :integration, [:controls] => [:lint, :check_attributes_file] do |_t, args|
+  task :integration, [:controls] => ['attributes:write', :lint] do |_t, args|
     cmd = %W( bin/inspec exec test/integration/verify
               --attrs terraform/#{ENV['ATTRIBUTES_FILE']}
               --reporter progress
@@ -210,7 +205,9 @@ end
 
 namespace :attributes do
   desc 'Create attributes used for integration testing'
-  task write: [:check_attributes_file] do
+  task :write do
+    abort('$ATTRIBUTES_FILE not set. Please source .envrc.') if ENV['ATTRIBUTES_FILE'].nil?
+    abort('$ATTRIBUTES_FILE has no content. Check .envrc.') if ENV['ATTRIBUTES_FILE'].empty?
     Rake::Task['tf:write_tf_output_to_file'].invoke
     Rake::Task['attributes:write_guest_presence_to_file'].invoke
   end

--- a/test/integration/verify/controls/azurerm_security_center_policies.rb
+++ b/test/integration/verify/controls/azurerm_security_center_policies.rb
@@ -1,13 +1,7 @@
-resource_group = attribute('resource_group', default: nil)
-
 control 'azurerm_security_center_policies' do
   describe azurerm_security_center_policies do
     it                  { should exist }
-    its('policy_names') { should include('default', resource_group) }
+    its('policy_names') { should include('default') }
   end
 
-  describe azurerm_security_center_policies.where(name: resource_group) do
-    it                  { should exist }
-    its('policy_names') { should eq([resource_group]) }
-  end
 end


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

### Description

Removes erroneous check for Security Policy - this is currently not executed and breaks CI. Followup task to create Policy via TF, but is blocked by API permission changes.

### Issues Resolved

CI.

### Check List

- [N/A] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
