### PR TITLE
fix spelling of StorageAccou(n)t class

### DIFF
--- a/libraries/azurerm_storage_account.rb
+++ b/libraries/azurerm_storage_account.rb
@@ -3,7 +3,7 @@
 require 'azurerm_resource'
 require 'date'
 
-class AzurermStorageAccout < AzurermSingularResource
+class AzurermStorageAccount < AzurermSingularResource
   name 'azurerm_storage_account'
   desc 'Verifies settings for a Azure Storage Account'
   example <<-EXAMPLE

--- a/libraries/azurerm_storage_account_blob_container.rb
+++ b/libraries/azurerm_storage_account_blob_container.rb
@@ -2,7 +2,7 @@
 
 require 'azurerm_resource'
 
-class AzurermStorageAccoutBlobContainer < AzurermSingularResource
+class AzurermStorageAccountBlobContainer < AzurermSingularResource
   name 'azurerm_storage_account_blob_container'
   desc 'Verifies settings for a Azure Storage Account Blob Container'
   example <<-EXAMPLE


### PR DESCRIPTION
### Description

Just trivially fixing one spelling

### Issues Resolved

probably none

### Check List

- [ ] New functionality includes tests -> NA
- [ ] All tests pass -> NA
- [ ] `rake lint` passes -> NA
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco> -> probably excused be virtue of triviality
