### PR TITLE
Updates maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,11 +19,17 @@ To mention the team, use @chef/dca-team
 
 ### Lieutenant
 
- * [David McCown](https://github.com/dmccown)
+ * [Stuart Paterson](https://github.com/skpaterson)
 
 ### Maintainers
 
+ * [Ruairi Fennell](https://github.com/r-fennell)
+ * [Davy MacAleer](https://github.com/davymcaleer)
+ * [Darren Murray](https://github.com/dmurray-chef)
+ * [James Stocks](https://github.com/james-stocks)
+ * [Rachel Rice](https://github.com/rachelrice)
+ * [Ross](https://github.com/rmoles)
+ * [Russel Seymour](https://github.com/russellseymour)
  * [Joshua Padgett](https://github.com/Padgett)
  * [Paul Welch](https://github.com/pwelch)
- * [Ruairi Fennell](https://github.com/r-fennell)
  * [Trevor Bramble](https://github.com/TrevorBramble)


### PR DESCRIPTION
Signed-off-by: David McCown <dmccown@chef.io>

### Description

This change updates the maintainers list to reflect the current group maintaining this project.

- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
