### PR TITLE
Have azurerm_management_groups use FilterTable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,52 +14,44 @@ RuboCop::RakeTask.new
 
 FIXTURE_DIR   = "#{Dir.pwd}/test/fixtures"
 TERRAFORM_DIR = 'terraform'
-REQUIRED_ENVS = %w{AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID}.freeze
+REQUIRED_ENVS = %w{AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID}.freeze
 
 task default: :test
 desc 'Testing tasks'
-task test: %w{test:unit setup_env test:integration}
-
-desc 'Set up Azure env, run integration tests, destroy Azure env'
-task azure: 'azure:run'
-
-namespace :azure do
-  task run: %w{network_watcher check_env tf:apply test:integration tf:destroy}
-
-  desc 'Authenticate with the Azure CLI'
-  task :login do
-    Rake::Task['check_env'].invoke
-
-    sh(
-      'az', 'login',
-      '--service-principal',
-      '-u', ENV['AZURE_CLIENT_ID'],
-      '-p', ENV['AZURE_CLIENT_SECRET'],
-      '--tenant', ENV['AZURE_TENANT_ID']
-    )
-  end
-end
+task test: %w{test:unit azure:login test:integration}
 
 desc 'Linting tasks'
-task lint: [:rubocop, :syntax, :'inspec:check']
+task lint: [:rubocop, :'syntax:ruby', :'syntax:inspec']
 
-desc 'Ruby syntax check'
-task :syntax do
-  files = %w{Gemfile Rakefile} + Dir['./**/*.rb']
+task :setup_env do
+  puts '-> Loading Environment Variables'
+  ENV['TF_VAR_subscription_id'] = ENV['AZURE_SUBSCRIPTION_ID']
+  ENV['TF_VAR_tenant_id']       = ENV['AZURE_TENANT_ID']
+  ENV['TF_VAR_client_id']       = ENV['AZURE_CLIENT_ID']
+  ENV['TF_VAR_client_secret']   = ENV['AZURE_CLIENT_SECRET']
+  ENV['TF_VAR_public_vm_count'] = '1' if ENV.key?('MSI')
 
-  files.each do |file|
-    sh('ruby', '-c', file) do |ok, res|
-      next if ok
+  puts '-> Ensuring required Environment Variables are set'
+  missing = REQUIRED_ENVS.reject { |var| ENV.key?(var) }
+  abort("ENV missing: #{missing.join(', ')}") if missing.any?
 
-      puts 'Syntax check FAILED'
-      exit res.exitstatus
+  # Notify user which optional components they are using
+  options = EnvironmentFile.options('.envrc')
+  if options.empty?
+    puts "-> You are not using any optional components. See the README for more information.\n\n"
+  else
+    puts "-> You are using the following optional components:\n\n"
+    options.each do |option|
+      puts "* #{option}\n"
     end
+    puts "\nTo change these options run: rake options[component] or add desired components to your .envrc file. See the README for more information.\n\n"
   end
 end
 
-namespace :inspec do
+namespace :syntax do
   desc 'InSpec syntax check'
-  task :check do
+  task :inspec do
+    puts '-> Checking Inspec Control Syntax'
     stdout, status = Open3.capture2('./bin/inspec check .')
 
     puts stdout
@@ -70,58 +62,51 @@ namespace :inspec do
 
     status.exitstatus
   end
-end
 
-task :output_options do
-  options = EnvironmentFile.options('.envrc')
+  desc 'Ruby syntax check'
+  task :ruby do
+    puts '-> Checking Ruby Syntax'
+    files = %w{Gemfile Rakefile} + Dir['./**/*.rb']
 
-  if options.empty?
-    puts "\nYou are not using any optional components. See the README for more information.\n\n"
-  else
-    puts "\nYou are using the following optional components:\n\n"
-    options.each do |option|
-      puts "* #{option}\n"
+    files.each do |file|
+      sh('ruby', '-c', file) do |ok, res|
+        next if ok
+
+        puts 'Syntax check FAILED'
+        exit res.exitstatus
+      end
     end
-    puts "\nTo change these options run: rake options[component]. See the README for more information.\n\n"
   end
 end
 
-desc 'Enables given optional components. See README for details.'
-task :options, :component do |_t_, args|
-  components = []
-  components << args[:component] if args[:component]
-  components += args.extras unless args.extras.nil?
-
-  begin
-    env_file = EnvironmentFile.new('.envrc')
-    env_file.synchronize(components)
-  rescue RuntimeError => e
-    puts e.message
+namespace :azure do
+  desc 'Authenticate with the Azure CLI'
+  task login: [:setup_env] do
+    puts '-> Logging into Azure'
+    sh(
+      'az', 'login',
+      '--service-principal',
+      '-u', ENV['AZURE_CLIENT_ID'],
+      '-p', ENV['AZURE_CLIENT_SECRET'],
+      '--tenant', ENV['AZURE_TENANT_ID']
+    )
+    puts '-> Setting Subscription'
+    sh(
+      'az', 'account', 'set',
+      '-s', ENV['AZURE_SUBSCRIPTION_ID']
+    )
   end
-end
-
-task :setup_env do
-  ENV['TF_VAR_subscription_id'] = ENV['AZURE_SUBSCRIPTION_ID']
-  ENV['TF_VAR_tenant_id']       = ENV['AZURE_TENANT_ID']
-  ENV['TF_VAR_client_id']       = ENV['AZURE_CLIENT_ID']
-  ENV['TF_VAR_client_secret']   = ENV['AZURE_CLIENT_SECRET']
-  ENV['TF_VAR_public_vm_count'] = '1' if ENV.key?('MSI')
-end
-
-task :check_env do
-  missing = REQUIRED_ENVS.reject { |var| ENV.key?(var) }
-
-  abort("ENV missing: #{missing.join(', ')}") if missing.any?
 end
 
 namespace :test do
+
   Rake::TestTask.new(:unit) do |t|
     t.libs << 'test/unit'
     t.libs << 'libraries'
     t.test_files = FileList['test/unit/**/*_test.rb']
   end
 
-  task :integration, [:controls] => ['attributes:write', :lint] do |_t, args|
+  task :integration, [:controls] => ['attributes:write', :lint, :setup_env] do |_t, args|
     cmd = %W( bin/inspec exec test/integration/verify
               --attrs terraform/#{ENV['ATTRIBUTES_FILE']}
               --reporter progress
@@ -139,7 +124,7 @@ end
 namespace :tf do
   workspace = ENV['WORKSPACE']
 
-  task init: [:setup_env] do
+  task init: [:'azure:login'] do
     abort('$WORKSPACE not set. Please source .envrc.') if workspace.nil?
     abort('$WORKSPACE has no content. Check .envrc.') if workspace.empty?
     Dir.chdir(TERRAFORM_DIR) do
@@ -165,7 +150,7 @@ namespace :tf do
   end
 
   desc 'Executes the Terraform plan'
-  task apply: [:workspace, :plan] do
+  task apply: [:plan] do
     Dir.chdir(TERRAFORM_DIR) do
       sh('terraform', 'apply', 'inspec-azure.plan')
     end
@@ -180,7 +165,7 @@ namespace :tf do
     end
   end
 
-  task write_tf_output_to_file: ['tf:workspace'] do
+  task write_tf_output_to_file: [:workspace] do
     Dir.chdir(TERRAFORM_DIR) do
       stdout, stderr, status = Open3.capture3('terraform output -json')
 
@@ -225,4 +210,16 @@ namespace :attributes do
   end
 end
 
-Rake.application.top_level_tasks << :output_options
+desc 'Enables given optional components. See README for details.'
+task :options, :component do |_t_, args|
+  components = []
+  components << args[:component] if args[:component]
+  components += args.extras unless args.extras.nil?
+
+  begin
+    env_file = EnvironmentFile.new('.envrc')
+    env_file.synchronize(components)
+  rescue RuntimeError => e
+    puts e.message
+  end
+end

--- a/docs/resources/azurerm_management_groups.md.erb
+++ b/docs/resources/azurerm_management_groups.md.erb
@@ -48,12 +48,8 @@ You'll also need to setup your Azure credentials; see the resource pack
 ### Check attributes of all management groups
 
   describe azurerm_management_groups do
-    its('ids')           { should include "/providers/Microsoft.Management/managementGroups/#{parent_mg}" }
-    its('ids')           { should include "/providers/Microsoft.Management/managementGroups/#{child1_mg}" }
-    its('ids')           { should include "/providers/Microsoft.Management/managementGroups/#{child2_mg}" }
-    its('names')         { should include parent_mg }
-    its('names')         { should include child1_mg }
-    its('names')         { should include child2_mg }
+    its('ids')           { should include "/providers/Microsoft.Management/managementGroups/mg_id" }
+    its('names')         { should include "parent_mg" }
     its('types')         { should include '/providers/Microsoft.Management/managementGroups' }
   end
 

--- a/docs/resources/azurerm_management_groups.md.erb
+++ b/docs/resources/azurerm_management_groups.md.erb
@@ -45,17 +45,22 @@ You'll also need to setup your Azure credentials; see the resource pack
 
 ## Examples
 
+### Check attributes of all management groups
+
   describe azurerm_management_groups do
-    its('group_ids')           { should include '/providers/Microsoft.Management/managementGroups/mg_one' }
-    its('group_ids')           { should include '/providers/Microsoft.Management/managementGroups/mg_two' }
-    its('group_names')         { should include 'mg_one' }
-    its('group_names')         { should include 'mg_two' }
-    its('group_types')         { should include '/providers/Microsoft.Management/managementGroups' }
-    its('group_tenant_ids')    { should include '00000000-0000-0000-0000-000000000000' }
-    its('group_display_names') { should include 'Management Group 1' }
-    its('group_display_names') { should include 'Management Group 2' }
+    its('ids')           { should include "/providers/Microsoft.Management/managementGroups/#{parent_mg}" }
+    its('ids')           { should include "/providers/Microsoft.Management/managementGroups/#{child1_mg}" }
+    its('ids')           { should include "/providers/Microsoft.Management/managementGroups/#{child2_mg}" }
+    its('names')         { should include parent_mg }
+    its('names')         { should include child1_mg }
+    its('names')         { should include child2_mg }
+    its('types')         { should include '/providers/Microsoft.Management/managementGroups' }
   end
 
+### Filter results to inspect the properties of specific Management Group.
+  describe azurerm_management_groups.where(name: 'mg_parent').entries.first do
+    its('properties') { should have_attributes(:tenantId => tenant_id, :displayName => parent_dn)}
+  end
 <br />
 
 ## Parameters
@@ -64,31 +69,26 @@ N/A
 
 ## Attributes
 
-  - `group_ids`
-  - `group_types`
-  - `group_names`
-  - `group_tenant_ids`
-  - `group_display_names`
+  - `ids`
+  - `types`
+  - `names`
+  - `properties`
 
-### group_ids
+### ids
 
 The management group ids.
 
-### group_types
+### types
 
 The management group types.
 
-### group_names
+### names
 
 The management group names.
 
-### group_tenant_ids
+### properties
 
-The management group tenant ids.
-
-### group_display_names
-
-The management group display names.
+Additional properties relating to management groups.
 
 ### Other Attributes
 
@@ -110,8 +110,18 @@ This InSpec audit resource has no special matchers. For a full list of
 available matchers, please visit our [Universal Matchers
 page](https://www.inspec.io/docs/reference/matchers/).
 
+### exists
+
+The control will pass if the filter returns at least one result. Use
+`should_not` if you expect zero matches.
+
+    describe azurerm_management_groups(name: 'my-mg') do
+      it { should exist }
+    end
+
+
 ## Azure Permissions
 
 Your [Service
 Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal)
-must be setup with a `contributor` role on the Tenant Root Group or the specific management group(s) you wish to test.
+must be setup with a `Contributor` or `Management Group Contributor` role on the Tenant Root Group or the specific management group(s) you wish to test.

--- a/libraries/azurerm_management_groups.rb
+++ b/libraries/azurerm_management_groups.rb
@@ -7,44 +7,27 @@ class AzurermManagementGroups < AzurermPluralResource
   desc 'Verifies settings for an Azure Management Groups'
   example <<-EXAMPLE
     describe azurerm_management_groups do
-      its('groups_names') { should include 'example-group' }
+      its('names') { should include 'example-group' }
     end
   EXAMPLE
 
-  ATTRS = [
-    :groups,
-  ].freeze
+  attr_reader :table
 
-  attr_reader(*ATTRS)
+  FilterTable.create
+      .register_column(:ids, field: :id)
+      .register_column(:types, field: :type)
+      .register_column(:names, field: :name)
+      .register_column(:properties, field: :properties)
+      .install_filter_methods_on_resource(self, :table)
 
   def initialize
     resp = management.management_groups
     return if has_error?(resp)
 
-    @groups = resp
+    @table = resp
   end
 
   def to_s
     'Management Groups'
-  end
-
-  def group_ids
-    groups.map(&:id)
-  end
-
-  def group_types
-    groups.map(&:type)
-  end
-
-  def group_names
-    groups.map(&:name)
-  end
-
-  def group_tenant_ids
-    groups.map { |x| x.properties.tenantId }
-  end
-
-  def group_display_names
-    groups.map { |x| x.properties.displayName }
   end
 end

--- a/libraries/azurerm_management_groups.rb
+++ b/libraries/azurerm_management_groups.rb
@@ -14,11 +14,11 @@ class AzurermManagementGroups < AzurermPluralResource
   attr_reader :table
 
   FilterTable.create
-      .register_column(:ids, field: :id)
-      .register_column(:types, field: :type)
-      .register_column(:names, field: :name)
-      .register_column(:properties, field: :properties)
-      .install_filter_methods_on_resource(self, :table)
+             .register_column(:ids, field: :id)
+             .register_column(:types, field: :type)
+             .register_column(:names, field: :name)
+             .register_column(:properties, field: :properties)
+             .install_filter_methods_on_resource(self, :table)
 
   def initialize
     resp = management.management_groups

--- a/terraform/azure.tf
+++ b/terraform/azure.tf
@@ -82,7 +82,6 @@ resource "azurerm_storage_account" "sa" {
 
 resource "azurerm_storage_container" "container" {
   name                  = "vhds"
-  resource_group_name   = "${azurerm_resource_group.rg.name}"
   storage_account_name  = "${azurerm_storage_account.sa.name}"
   container_access_type = "private"
 }
@@ -95,7 +94,6 @@ resource "random_pet" "blob_name" {
 
 resource "azurerm_storage_container" "blob" {
   name                  = "${random_pet.blob_name.id}"
-  resource_group_name   = "${azurerm_resource_group.rg.name}"
   storage_account_name  = "${azurerm_storage_account.sa.name}"
   container_access_type = "private"
 }
@@ -111,10 +109,7 @@ resource "azurerm_key_vault" "disk_vault" {
   location            = "${var.location}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   tenant_id           = "${var.tenant_id}"
-
-  sku {
-    name = "premium"
-  }
+  sku_name            = "premium"
 
   access_policy {
     tenant_id = "${var.tenant_id}"
@@ -147,12 +142,12 @@ resource "azurerm_key_vault" "disk_vault" {
 resource "azurerm_key_vault_secret" "vs" {
   name      = "secret"
   value     = "${random_string.password.result}"
-  vault_uri = "${azurerm_key_vault.disk_vault.vault_uri}"
+  key_vault_id = "${azurerm_key_vault.disk_vault.id}"
 }
 
 resource "azurerm_key_vault_key" "vk" {
   name      = "key"
-  vault_uri = "${azurerm_key_vault.disk_vault.vault_uri}"
+  key_vault_id = "${azurerm_key_vault.disk_vault.id}"
   key_type  = "EC"
   key_size  = 2048
 
@@ -221,9 +216,11 @@ resource "azurerm_subnet" "subnet" {
   resource_group_name  = "${azurerm_resource_group.rg.name}"
   virtual_network_name = "${azurerm_virtual_network.vnet.name}"
   address_prefix       = "10.1.1.0/24"
+}
 
-  # Attach the NSG to the subnet
+resource "azurerm_subnet_network_security_group_association" "subnet_nsg" {
   network_security_group_id = "${azurerm_network_security_group.nsg.id}"
+  subnet_id = "${azurerm_subnet.subnet.id}"
 }
 
 resource "azurerm_network_interface" "nic1" {
@@ -406,14 +403,11 @@ module "activity_log_alert_5_3" {
   activity_log_alert_name = "${var.activity_log_alert["log_alert"]}"
   resource_group          = "${azurerm_resource_group.rg.name}"
   action_group            = "${var.activity_log_alert["action_group"]}"
-
-  # Wait for resources and associations to be created
   depends_on = ["${null_resource.azure_action_group.triggers}"]
 }
 
 module "activity_log_alert_5_4" {
   source = "modules/activity_log_alert"
-
   name                    = "5_4"
   condition               = "category=Administrative and operationName=Microsoft.Network/networkSecurityGroups/write"
   activity_log_alert_name = "${var.activity_log_alert["log_alert"]}"
@@ -425,97 +419,81 @@ module "activity_log_alert_5_4" {
 
 module "activity_log_alert_5_5" {
   source = "modules/activity_log_alert"
-
   name                    = "5_5"
   condition               = "category=Administrative and operationName=Microsoft.Network/networkSecurityGroups/delete"
   activity_log_alert_name = "${var.activity_log_alert["log_alert"]}"
   resource_group          = "${azurerm_resource_group.rg.name}"
   action_group            = "${var.activity_log_alert["action_group"]}"
-
   depends_on = ["${null_resource.azure_action_group.triggers}"]
 }
 
 module "activity_log_alert_5_6" {
   source = "modules/activity_log_alert"
-
   name                    = "5_6"
   condition               = "category=Administrative and operationName=Microsoft.Network/networkSecurityGroups/securityRules/write"
   activity_log_alert_name = "${var.activity_log_alert["log_alert"]}"
   resource_group          = "${azurerm_resource_group.rg.name}"
   action_group            = "${var.activity_log_alert["action_group"]}"
-
   depends_on = ["${null_resource.azure_action_group.triggers}"]
 }
 
 module "activity_log_alert_5_7" {
   source = "modules/activity_log_alert"
-
   name                    = "5_7"
   condition               = "category=Administrative and operationName=Microsoft.Network/networkSecurityGroups/securityRules/delete"
   activity_log_alert_name = "${var.activity_log_alert["log_alert"]}"
   resource_group          = "${azurerm_resource_group.rg.name}"
   action_group            = "${var.activity_log_alert["action_group"]}"
-
   depends_on = ["${null_resource.azure_action_group.triggers}"]
 }
 
 module "activity_log_alert_5_8" {
   source = "modules/activity_log_alert"
-
   name                    = "5_8"
   condition               = "category=Administrative and operationName=Microsoft.Security/securitySolutions/write"
   activity_log_alert_name = "${var.activity_log_alert["log_alert"]}"
   resource_group          = "${azurerm_resource_group.rg.name}"
   action_group            = "${var.activity_log_alert["action_group"]}"
-
   depends_on = ["${null_resource.azure_action_group.triggers}"]
 }
 
 module "activity_log_alert_5_9" {
   source = "modules/activity_log_alert"
-
   name                    = "5_9"
   condition               = "category=Administrative and operationName=Microsoft.Security/securitySolutions/delete"
   activity_log_alert_name = "${var.activity_log_alert["log_alert"]}"
   resource_group          = "${azurerm_resource_group.rg.name}"
   action_group            = "${var.activity_log_alert["action_group"]}"
-
   depends_on = ["${null_resource.azure_action_group.triggers}"]
 }
 
 module "activity_log_alert_5_10" {
   source = "modules/activity_log_alert"
-
   name                    = "5_10"
   condition               = "category=Administrative and operationName=Microsoft.Sql/servers/firewallRules/write"
   activity_log_alert_name = "${var.activity_log_alert["log_alert"]}"
   resource_group          = "${azurerm_resource_group.rg.name}"
   action_group            = "${var.activity_log_alert["action_group"]}"
-
   depends_on = ["${null_resource.azure_action_group.triggers}"]
 }
 
 module "activity_log_alert_5_11" {
   source = "modules/activity_log_alert"
-
   name                    = "5_11"
   condition               = "category=Administrative and operationName=Microsoft.Sql/servers/firewallRules/delete"
   activity_log_alert_name = "${var.activity_log_alert["log_alert"]}"
   resource_group          = "${azurerm_resource_group.rg.name}"
   action_group            = "${var.activity_log_alert["action_group"]}"
-
   depends_on = ["${null_resource.azure_action_group.triggers}"]
 }
 
 module "activity_log_alert_5_12" {
   source = "modules/activity_log_alert"
-
   name                    = "5_12"
   condition               = "category=Administrative and operationName=Microsoft.Security/policies/write"
   activity_log_alert_name = "${var.activity_log_alert["log_alert"]}"
   resource_group          = "${azurerm_resource_group.rg.name}"
   action_group            = "${var.activity_log_alert["action_group"]}"
-
   depends_on = ["${null_resource.azure_action_group.triggers}"]
 }
 
@@ -652,7 +630,7 @@ resource "tls_private_key" "key" {
   rsa_bits  = 4096
 }
 
-resource "azurerm_kubernetes_cluster" "test" {
+resource "azurerm_kubernetes_cluster" "cluster" {
   name                = "inspecakstest"
   location            = "${azurerm_resource_group.rg.location}"
   resource_group_name = "${azurerm_resource_group.rg.name}"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -180,9 +180,25 @@ output "storage_account_blob_container" {
 }
 
 output "cluster_fqdn" {
-  value = "${azurerm_kubernetes_cluster.test.fqdn}"
+  value = "${azurerm_kubernetes_cluster.cluster.fqdn}"
 }
 
 output "tenant_id" {
   value = "${var.tenant_id}"
+}
+
+output "parent_mg" {
+  value = "${azurerm_management_group.mg_parent.group_id}"
+}
+
+output "child1_mg" {
+  value = "${azurerm_management_group.mg_child_one.group_id}"
+}
+
+output "child2_mg" {
+  value = "${azurerm_management_group.mg_child_two.group_id}"
+}
+
+output "parent_dn" {
+  value = "${azurerm_management_group.mg_parent.display_name}"
 }

--- a/test/integration/verify/controls/azurerm_management_group.rb
+++ b/test/integration/verify/controls/azurerm_management_group.rb
@@ -1,31 +1,36 @@
 tenant_id = attribute('tenant_id', default: nil)
+parent_mg = attribute('parent_mg', default: nil)
+child1_mg = attribute('child1_mg', default: nil)
+child2_mg = attribute('child2_mg', default: nil)
+parent_dn = attribute('parent_dn', default: nil)
+mg_type   = '/providers/Microsoft.Management/managementGroups'
 
 control 'azurerm_management_group' do
-  describe azurerm_management_group(group_id: 'mg_parent', expand: 'children', recurse: true) do
+  describe azurerm_management_group(group_id: parent_mg, expand: 'children', recurse: true) do
     it                            { should exist }
-    its('id')                     { should eq '/providers/Microsoft.Management/managementGroups/mg_parent' }
-    its('type')                   { should eq '/providers/Microsoft.Management/managementGroups' }
-    its('name')                   { should eq 'mg_parent' }
-    its('display_name')           { should eq 'Management Group Parent' }
+    its('id')                     { should eq "#{mg_type}/#{parent_mg}"}
+    its('type')                   { should eq mg_type   }
+    its('name')                   { should eq parent_mg }
+    its('display_name')           { should eq parent_dn }
     its('tenant_id')              { should eq tenant_id }
+    its('children_ids')           { should include "#{mg_type}/#{child1_mg}" }
+    its('children_ids')           { should include "#{mg_type}/#{child2_mg}" }
+    its('children_names')         { should include child1_mg }
+    its('children_names')         { should include child2_mg }
+    its('children_types')         { should include mg_type }
     its('children_display_names') { should include 'Management Group Child 1' }
     its('children_display_names') { should include 'Management Group Child 2' }
-    its('children_ids')           { should include '/providers/Microsoft.Management/managementGroups/mg_child_one' }
-    its('children_ids')           { should include '/providers/Microsoft.Management/managementGroups/mg_child_two' }
-    its('children_names')         { should include 'mg_child_one' }
-    its('children_names')         { should include 'mg_child_two' }
-    its('children_types')         { should include '/providers/Microsoft.Management/managementGroups' }
   end
 
-  describe azurerm_management_group(group_id: 'mg_child_one', expand: 'children', recurse: true) do
+  describe azurerm_management_group(group_id: child1_mg, expand: 'children', recurse: true) do
     it                            { should exist }
-    its('id')                     { should eq '/providers/Microsoft.Management/managementGroups/mg_child_one' }
-    its('type')                   { should eq '/providers/Microsoft.Management/managementGroups' }
-    its('name')                   { should eq 'mg_child_one' }
-    its('display_name')           { should eq 'Management Group Child 1' }
+    its('id')                     { should eq "#{mg_type}/#{child1_mg}" }
+    its('type')                   { should eq mg_type   }
+    its('name')                   { should eq child1_mg }
     its('tenant_id')              { should eq tenant_id }
-    its('parent_name')            { should eq 'mg_parent' }
-    its('parent_id')              { should eq '/providers/Microsoft.Management/managementGroups/mg_parent' }
+    its('parent_name')            { should eq parent_mg }
+    its('parent_id')              { should eq "#{mg_type}/#{parent_mg}"}
+    its('display_name')           { should eq 'Management Group Child 1' }
     its('parent_display_name')    { should eq 'Management Group Parent' }
     its('children_display_names') { should eq [] }
     its('children_ids')           { should eq [] }
@@ -33,15 +38,15 @@ control 'azurerm_management_group' do
     its('children_types')         { should eq [] }
   end
 
-  describe azurerm_management_group(group_id: 'mg_child_two', expand: 'children', recurse: true) do
+  describe azurerm_management_group(group_id: child2_mg, expand: 'children', recurse: true) do
     it                            { should exist }
-    its('id')                     { should eq '/providers/Microsoft.Management/managementGroups/mg_child_two' }
-    its('type')                   { should eq '/providers/Microsoft.Management/managementGroups' }
-    its('name')                   { should eq 'mg_child_two' }
-    its('display_name')           { should eq 'Management Group Child 2' }
+    its('id')                     { should eq "#{mg_type}/#{child2_mg}" }
+    its('type')                   { should eq mg_type   }
+    its('name')                   { should eq child2_mg }
     its('tenant_id')              { should eq tenant_id }
-    its('parent_name')            { should eq 'mg_parent' }
-    its('parent_id')              { should eq '/providers/Microsoft.Management/managementGroups/mg_parent' }
+    its('parent_name')            { should eq parent_mg }
+    its('parent_id')              { should eq "#{mg_type}/#{parent_mg}"}
+    its('display_name')           { should eq 'Management Group Child 2' }
     its('parent_display_name')    { should eq 'Management Group Parent' }
     its('children_display_names') { should eq [] }
     its('children_ids')           { should eq [] }

--- a/test/integration/verify/controls/azurerm_management_group.rb
+++ b/test/integration/verify/controls/azurerm_management_group.rb
@@ -8,7 +8,7 @@ mg_type   = '/providers/Microsoft.Management/managementGroups'
 control 'azurerm_management_group' do
   describe azurerm_management_group(group_id: parent_mg, expand: 'children', recurse: true) do
     it                            { should exist }
-    its('id')                     { should eq "#{mg_type}/#{parent_mg}"}
+    its('id')                     { should eq "#{mg_type}/#{parent_mg}" }
     its('type')                   { should eq mg_type   }
     its('name')                   { should eq parent_mg }
     its('display_name')           { should eq parent_dn }
@@ -29,7 +29,7 @@ control 'azurerm_management_group' do
     its('name')                   { should eq child1_mg }
     its('tenant_id')              { should eq tenant_id }
     its('parent_name')            { should eq parent_mg }
-    its('parent_id')              { should eq "#{mg_type}/#{parent_mg}"}
+    its('parent_id')              { should eq "#{mg_type}/#{parent_mg}" }
     its('display_name')           { should eq 'Management Group Child 1' }
     its('parent_display_name')    { should eq 'Management Group Parent' }
     its('children_display_names') { should eq [] }
@@ -45,7 +45,7 @@ control 'azurerm_management_group' do
     its('name')                   { should eq child2_mg }
     its('tenant_id')              { should eq tenant_id }
     its('parent_name')            { should eq parent_mg }
-    its('parent_id')              { should eq "#{mg_type}/#{parent_mg}"}
+    its('parent_id')              { should eq "#{mg_type}/#{parent_mg}" }
     its('display_name')           { should eq 'Management Group Child 2' }
     its('parent_display_name')    { should eq 'Management Group Parent' }
     its('children_display_names') { should eq [] }

--- a/test/integration/verify/controls/azurerm_management_groups.rb
+++ b/test/integration/verify/controls/azurerm_management_groups.rb
@@ -16,6 +16,6 @@ control 'azurerm_management_groups' do
   end
 
   describe azurerm_management_groups.where(name: 'mg_parent').entries.first do
-    its('properties') { should have_attributes(:tenantId => tenant_id, :displayName => parent_dn)}
+    its('properties') { should have_attributes(tenantId: tenant_id, displayName: parent_dn) }
   end
 end

--- a/test/integration/verify/controls/azurerm_management_groups.rb
+++ b/test/integration/verify/controls/azurerm_management_groups.rb
@@ -1,16 +1,21 @@
 tenant_id = attribute('tenant_id', default: nil)
+parent_mg = attribute('parent_mg', default: nil)
+child1_mg = attribute('child1_mg', default: nil)
+child2_mg = attribute('child2_mg', default: nil)
+parent_dn = attribute('parent_dn', default: nil)
 
 control 'azurerm_management_groups' do
   describe azurerm_management_groups do
-    its('group_ids')           { should include '/providers/Microsoft.Management/managementGroups/mg_child_one' }
-    its('group_ids')           { should include '/providers/Microsoft.Management/managementGroups/mg_child_two' }
-    its('group_names')         { should include 'mg_parent' }
-    its('group_names')         { should include 'mg_child_one' }
-    its('group_names')         { should include 'mg_child_two' }
-    its('group_types')         { should include '/providers/Microsoft.Management/managementGroups' }
-    its('group_tenant_ids')    { should include tenant_id }
-    its('group_display_names') { should include 'Management Group Parent' }
-    its('group_display_names') { should include 'Management Group Child 1' }
-    its('group_display_names') { should include 'Management Group Child 2' }
+    its('ids')           { should include "/providers/Microsoft.Management/managementGroups/#{parent_mg}" }
+    its('ids')           { should include "/providers/Microsoft.Management/managementGroups/#{child1_mg}" }
+    its('ids')           { should include "/providers/Microsoft.Management/managementGroups/#{child2_mg}" }
+    its('names')         { should include parent_mg }
+    its('names')         { should include child1_mg }
+    its('names')         { should include child2_mg }
+    its('types')         { should include '/providers/Microsoft.Management/managementGroups' }
+  end
+
+  describe azurerm_management_groups.where(name: 'mg_parent').entries.first do
+    its('properties') { should have_attributes(:tenantId => tenant_id, :displayName => parent_dn)}
   end
 end


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

### Description

Updates `azurerm_management_groups` to use the FIlterTable syntax, allowing filtering in controls.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
