### PR TITLE
Additional methods for default security center policy

### DIFF
--- a/libraries/azurerm_security_center_policy.rb
+++ b/libraries/azurerm_security_center_policy.rb
@@ -56,6 +56,14 @@ class AzurermSecurityCenterPolicy < AzurermSingularResource
     @exists = true
   end
 
+  def default_policy
+    management.scp_default_policy
+  end
+
+  def has_auto_provisioning_enabled?
+    management.scp_auto_provisioning_settings.first.properties.autoProvision == 'On'
+  end
+
   def to_s
     "'#{name}' Security Policy"
   end

--- a/libraries/support/azure/management.rb
+++ b/libraries/support/azure/management.rb
@@ -139,6 +139,20 @@ module Azure
       )
     end
 
+    def scp_auto_provisioning_settings
+      get(
+        url: link(location: 'Microsoft.Security/autoProvisioningSettings'),
+        api_version: '2017-08-01-preview',
+      )
+    end
+
+    def scp_default_policy
+      get(
+        url: link(location: 'Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn'),
+        api_version: '2018-05-01',
+        )
+    end
+
     def storage_account(resource_group, name)
       get(
         url: link(location: "Microsoft.Storage/storageAccounts/#{name}",

--- a/libraries/support/azure/management.rb
+++ b/libraries/support/azure/management.rb
@@ -150,7 +150,7 @@ module Azure
       get(
         url: link(location: 'Microsoft.Authorization/policyAssignments/SecurityCenterBuiltIn'),
         api_version: '2018-05-01',
-        )
+      )
     end
 
     def storage_account(resource_group, name)

--- a/test/integration/verify/controls/azurerm_security_center_policy.rb
+++ b/test/integration/verify/controls/azurerm_security_center_policy.rb
@@ -14,6 +14,7 @@ control 'azurerm_security_center_policy' do
 
   describe azurerm_security_center_policy(name: 'default') do
     it                                     { should exist }
+    it                                     { should have_auto_provisioning_enabled }
     its('id')                              { should eq("/subscriptions/#{ENV['AZURE_SUBSCRIPTION_ID']}/providers/Microsoft.Security/policies/default") }
     its('name')                            { should eq('default') }
     its('log_collection')                  { should eq('On').or eq('Off') }
@@ -34,6 +35,7 @@ control 'azurerm_security_center_policy' do
     its('send_security_email_to_admin')    { should eq(true).or eq(false) }
     its('contact_emails')                  { should_not be_nil }
     its('contact_phone')                   { should_not be_nil }
+    its('default_policy')                  { is_expected.to respond_to(:properties)  }
   end
 
   # only supports looking up the security center policy named 'default'

--- a/test/integration/verify/controls/azurerm_security_center_policy.rb
+++ b/test/integration/verify/controls/azurerm_security_center_policy.rb
@@ -35,7 +35,7 @@ control 'azurerm_security_center_policy' do
     its('send_security_email_to_admin')    { should eq(true).or eq(false) }
     its('contact_emails')                  { should_not be_nil }
     its('contact_phone')                   { should_not be_nil }
-    its('default_policy')                  { is_expected.to respond_to(:properties)  }
+    its('default_policy')                  { is_expected.to respond_to(:properties) }
   end
 
   # only supports looking up the security center policy named 'default'


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

### Description

Adds ability to retrieve the Default ASC Policy (further documentation [here](https://docs.microsoft.com/en-us/azure/security-center/tutorial-security-policy#how-security-policies-work).

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
