### PR TITLE
Fix inspec_version, remove redundant rakefile calls

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ REQUIRED_ENVS = %w{AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUB
 
 task default: :test
 desc 'Testing tasks'
-task test: %w{test:unit azure:login test:integration}
+task test: %w{lint test:unit test:integration}
 
 desc 'Linting tasks'
 task lint: [:rubocop, :'syntax:ruby', :'syntax:inspec']
@@ -101,13 +101,12 @@ end
 namespace :test do
 
   Rake::TestTask.new(:unit) do |t|
-    puts '-> Running Unit Tests'
     t.libs << 'test/unit'
     t.libs << 'libraries'
     t.test_files = FileList['test/unit/**/*_test.rb']
   end
 
-  task :integration, [:controls] => [:lint, :unit, 'attributes:write', :setup_env] do |_t, args|
+  task :integration, [:controls] => ['attributes:write', :setup_env] do |_t, args|
     cmd = %W( bin/inspec exec test/integration/verify
               --input-file terraform/#{ENV['ATTRIBUTES_FILE']}
               --reporter progress

--- a/inspec.yml
+++ b/inspec.yml
@@ -6,6 +6,6 @@ copyright_email: support@chef.io
 license: Apache-2.0
 summary: This resource pack provides compliance resources for Azure.
 version: 1.9.1
-inspec_version: 1.9.1
+inspec_version: '>= 4.0.0'
 supports:
   - platform: azure


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

### Description
Integration tests on CI are currently very loud and repeat steps unnessecarily. This changes fixes some rake task dependencies to allow better pipelining in jenkins.

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
