### PR TITLE
Bump inspec version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,9 @@
 
 source 'https://rubygems.org'
 
-gem 'activesupport',       '~> 5.2.3'
 gem 'faraday',             '~> 0.15.0'
 gem 'faraday_middleware',  '~> 0.12.2'
-gem 'inspec-bin'
+gem 'inspec-bin',          '~> 4.18.39'
 gem 'rake',                '~> 12.3', '>= 12.3.1'
 
 group :development do

--- a/libraries/azurerm_network_watchers.rb
+++ b/libraries/azurerm_network_watchers.rb
@@ -17,7 +17,7 @@ class AzurermNetworkWatchers < AzurermPluralResource
              .register_column(:names, field: :name)
              .install_filter_methods_on_resource(self, :table)
 
-  def initialize(resource_group:)
+  def initialize(resource_group = nil)
     resp = management.network_watchers(resource_group)
     return if has_error?(resp)
 


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

### Description

Bumps inspec-bin version to pull in activesupport gem.
Changes azurerm_network_watchers constructor to be more consistent with other resources.

### Issues Resolved
https://github.com/inspec/inspec-azure/issues/216

### Check List

- [N/A] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
