### PR TITLE
Inspec Check fix

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,7 @@ RuboCop::RakeTask.new
 FIXTURE_DIR   = "#{Dir.pwd}/test/fixtures"
 TERRAFORM_DIR = 'terraform'
 REQUIRED_ENVS = %w{AZURE_CLIENT_ID AZURE_CLIENT_SECRET AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID}.freeze
+INTEGRATION_DIR = 'test/integration/verify'
 
 task default: :test
 desc 'Testing tasks'
@@ -52,8 +53,9 @@ namespace :syntax do
   desc 'InSpec syntax check'
   task :inspec do
     puts '-> Checking Inspec Control Syntax'
-    stdout, status = Open3.capture2('./bin/inspec check .')
-
+    stdout, status = Open3.capture2("./bin/inspec vendor #{INTEGRATION_DIR} --overwrite &&
+                                     ./bin/inspec check #{INTEGRATION_DIR} &&
+                                     ./bin/inspec check .")
     puts stdout
 
     %w{errors}.each do |type|
@@ -107,7 +109,7 @@ namespace :test do
   end
 
   task :integration, [:controls] => ['attributes:write', :setup_env] do |_t, args|
-    cmd = %W( bin/inspec exec test/integration/verify
+    cmd = %W( bin/inspec exec #{INTEGRATION_DIR}
               --input-file terraform/#{ENV['ATTRIBUTES_FILE']}
               --reporter progress
               --no-distinct-exit

--- a/test/integration/verify/controls/azurerm_network_watcher.rb
+++ b/test/integration/verify/controls/azurerm_network_watcher.rb
@@ -1,6 +1,6 @@
 resource_group = input('resource_group',       value: nil)
-nw             = input('network_watcher_name', value: nil).first
-nw_id          = input('network_watcher_id',   value: nil).first
+nw             = input('network_watcher_name', value: []).first
+nw_id          = input('network_watcher_id',   value: []).first
 
 control 'azurerm_network_watcher' do
   only_if { ENV['NETWORK_WATCHER'] }

--- a/test/integration/verify/controls/azurerm_skip_base_controls.rb
+++ b/test/integration/verify/controls/azurerm_skip_base_controls.rb
@@ -1,3 +1,0 @@
-require_controls 'azure' do
-  # skip controls from base profile
-end

--- a/test/integration/verify/controls/azurerm_virtual_machines.rb
+++ b/test/integration/verify/controls/azurerm_virtual_machines.rb
@@ -1,7 +1,7 @@
 resource_group     = input('resource_group',     value: nil)
-vm_names           = input('vm_names',           value: nil)
-os_disks           = input('os_disks',           value: nil)
-data_disks         = input('managed_data_disks', value: nil)
+vm_names           = input('vm_names',           value: [])
+os_disks           = input('os_disks',           value: [])
+data_disks         = input('managed_data_disks', value: [])
 
 windows_vm_names   = vm_names.select { |disk| disk.match(/windows/i) }
 linux_vm_names     = vm_names.select { |disk| disk.match(/linux/i) }

--- a/test/integration/verify/inspec.yml
+++ b/test/integration/verify/inspec.yml
@@ -1,4 +1,14 @@
-name: inspec-azure-integration-tests
+name: Inspec Azure Integration Test Profile
+title: Inspec Azure Integration Test Profile
+maintainer: Chef Software, Inc.
+copyright: Chef Software, Inc.
+copyright_email: support@chef.io
+license: Apache-2.0
+summary: This profile is a simple wrapper around the controls defined in the integration test directory.
+version: 1
+inspec_version: '>= 4.18.39'
 depends:
-  - name: azure
-    path: ../../../
+  - name: this-depend-loads-resources
+    path: ../../..
+supports:
+  - platform: azure


### PR DESCRIPTION
Signed-off-by: Ruairi Fennell <rfennell@chef.io>

### Description

Currently inspec check is not executed against the integration test controls, and some failures have slipped in. This change fixes those failures, ensures we check those controls going forward and also the validity of the root inspec.yml.

### Issues Resolved

https://github.com/inspec/inspec-azure/issues/201

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
