### PR TITLE
Offload user filtering to Azure API to avoid resource issues in large AD

### DIFF
--- a/libraries/azurerm_ad_users.rb
+++ b/libraries/azurerm_ad_users.rb
@@ -21,8 +21,9 @@ class AzurermAdUsers < AzurermPluralResource
              .register_column(:user_types,     field: :userType)
              .install_filter_methods_on_resource(self, :table)
 
-  def initialize
-    resp = graph.users
+  def initialize(params = {})
+    @params = params
+    resp = graph.users(@params)
     return if has_error?(resp)
 
     @table = resp
@@ -35,6 +36,10 @@ class AzurermAdUsers < AzurermPluralResource
   end
 
   def to_s
-    'Azure Active Directory Users'
+    if @params[:filter]
+      "Azure Active Directory Users with filter( #{@params[:filter]} )"
+    else
+      'Azure Active Directory Users'
+    end
   end
 end

--- a/libraries/support/azure/graph.rb
+++ b/libraries/support/azure/graph.rb
@@ -21,12 +21,15 @@ module Azure
       )
     end
 
-    def users
+    def users(raw_params = {})
+      cooked_params = {}
+      cooked_params['$filter'] = raw_params[:filter] unless raw_params[:filter].nil?
       get(
         url:           "/#{tenant_id}/users",
         api_version:   '1.6',
         error_handler: handle_error,
         unwrap:        unwrap,
+        params:        cooked_params,
       )
     end
 


### PR DESCRIPTION
### Description

Suggested fix for #198 where we get failures testing for guest accounts in large AD because we run out of memory (after waiting a LONG time for the whole AD to be downloaded)

This PR could allow a wrapper profile (such as CIS Azure) to offload filtering to Azure instead of pulling all the accounts back to the Inspec machine to perform local filtering. This is especially useful in AD with more than 500k accounts.

This PR would allow the CIS Azure profile to test in a similar way to this:-

```
control "guest-users" do
  impact 0.7
  title "There should be no guest users"
  desc "Guest users are bad"
  describe azurerm_ad_users(filter: "userType eq 'Guest'") do
    its('display_names') { should eq [] }
    its('count') {should eq 0}
  end
end
```

