### PR TITLE
enable support for cinc auditor

### DIFF
--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -8,7 +8,7 @@ ruby -v
 bundle --version
 
 echo "--- bundle install"
-bundle install --jobs=7 --retry=3 --without tools maintenance deploy
+bundle install --jobs=7 --retry=3 --with test --without tools maintenance deploy
 
 echo "+++ bundle exec rake lint"
 bundle exec rake lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
 before_install:
   - gem update --remote bundler
 install:
-  - bundle install --retry=3
+  - bundle install --with test --retry=3
 script:
   - bundle exec rake test:unit
   - bundle exec rake lint

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
 end
 
 group :developmen, :test do
-  gem 'inspec-bin' , '~> 4.18.39'
-  gem 'minitest'   , '~> 5.11.0'
-  gem 'rubocop'    , '~> 0.71.0'
+  gem 'inspec-bin', '~> 4.18.39'
+  gem 'minitest',   '~> 5.11.0'
+  gem 'rubocop',    '~> 0.71.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 gem 'faraday',             '~> 0.15.0'
 gem 'faraday_middleware',  '~> 0.12.2'
-gem 'inspec-bin',          '~> 4.18.39'
 gem 'rake',                '~> 12.3', '>= 12.3.1'
 
 group :development do
@@ -12,6 +11,7 @@ group :development do
 end
 
 group :developmen, :test do
-  gem 'minitest', '~> 5.11.0'
-  gem 'rubocop',  '~> 0.71.0'
+  gem 'inspec-bin' , '~> 4.18.39'
+  gem 'minitest'   , '~> 5.11.0'
+  gem 'rubocop'    , '~> 0.71.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,14 @@ source 'https://rubygems.org'
 
 gem 'faraday',             '~> 0.15.0'
 gem 'faraday_middleware',  '~> 0.12.2'
+gem 'inspec',              '~> 4.18.39'
 gem 'rake',                '~> 12.3', '>= 12.3.1'
 
 group :development do
   gem 'pry', '~> 0.11.3'
 end
 
-group :developmen, :test do
+group :developmen, :test , optional: true do
   gem 'inspec-bin', '~> 4.18.39'
   gem 'minitest',   '~> 5.11.0'
   gem 'rubocop',    '~> 0.71.0'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development do
   gem 'pry', '~> 0.11.3'
 end
 
-group :developmen, :test , optional: true do
+group :developmen, :test, optional: true do
   gem 'inspec-bin', '~> 4.18.39'
   gem 'minitest',   '~> 5.11.0'
   gem 'rubocop',    '~> 0.71.0'

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This InSpec resource pack uses the Azure REST API and provides the required reso
 * Azure Service Principal Account
 * Azure Service Principal may read the Azure Active Directory
 
+## Optional
+* Inspec-bin installed
+
 ### Service Principal
 
 Your Azure Service Principal Account must have `contributor` role to any subscription that you'd like to use this resource pack against. You should have the following pieces of information:

--- a/docs/reference/connectors.md
+++ b/docs/reference/connectors.md
@@ -103,7 +103,7 @@ two entries:
 
 ```
 $ export AZURE_SUBSCRIPTION_NUMBER=2
-$ bundle exec insepc exec . -t azure://
+$ bundle exec inspec exec . -t azure://
 ```
 
 ## Managed Service Identity Connector


### PR DESCRIPTION
### Description

This PR removes the strict dependency of inspec-bin as it isn't really required for the resource pack itself.

### Issues Resolved

#228 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
