### PR TITLE
Fix azurerm_network_interface have_public_address_ip false positives & Add private a public IP address methods

### DIFF
--- a/docs/resources/azurerm_network_interface.md.erb
+++ b/docs/resources/azurerm_network_interface.md.erb
@@ -75,6 +75,8 @@ If a Network Interface is referenced with an invalid `Resource Group` or `Name`
 - `properties`
 - `tags`
 - `type`
+- `private_ip`
+- `public_ip`
 
 ### id
 Azure resource ID.
@@ -93,6 +95,12 @@ Resource tags applied to the Network Interface.
 
 ### type
 The type of Resource, typically `Microsoft.Network/networkInterfaces`.
+
+### private_ip
+The Network interface private IP.
+
+### public_ip
+The Network interface public IP.
 
 ### Other Attributes
 

--- a/libraries/azurerm_network_interface.rb
+++ b/libraries/azurerm_network_interface.rb
@@ -34,11 +34,11 @@ class AzurermNetworkInterface < AzurermSingularResource
   end
 
   def has_private_address_ip?
-    !!properties.ipConfigurations[0].properties.privateIPAddress
+    !properties.ipConfigurations[0].properties.privateIPAddress.to_s.empty?
   end
 
   def has_public_address_ip?
-    !!properties.ipConfigurations[0].properties.publicIPAddress
+    !properties.ipConfigurations[0].properties.publicIPAddress.to_s.empty?
   end
 
   def to_s

--- a/libraries/azurerm_network_interface.rb
+++ b/libraries/azurerm_network_interface.rb
@@ -33,6 +33,14 @@ class AzurermNetworkInterface < AzurermSingularResource
     @exists = true
   end
 
+  def private_ip
+    properties.ipConfigurations.first.properties.privateIPAddress || nil
+  end
+
+  def public_ip
+    properties.ipConfigurations.first.properties.privateIPAddress || nil
+  end
+
   def has_private_address_ip?
     !properties.ipConfigurations[0].properties.privateIPAddress.to_s.empty?
   end


### PR DESCRIPTION
### Description

The current `has_public_address_ip?` method is using the following check `!!properties.ipConfigurations[0].properties.publicIPAddress`
This will only return false if the field is nil. Updating to `!properties.ipConfigurations[0].properties.publicIPAddress.to_s.empty?` covers nil and an empty string.
Fixes #235 

Also adds private and public ip address methods
Fixes #231
Please describe what this change achieves. Ensure you have read the [Contributing to InSpec](https://github.com/inspec/inspec-azure/CONTRIBUTING.MD) document before submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>

Signed-off-by: Ross Moles <rmoles@chef.io>
