### PR TITLE
Add allow_port_from_internet matcher to azurerm_network_security_group

### DIFF
--- a/docs/resources/azurerm_network_security_group.md.erb
+++ b/docs/resources/azurerm_network_security_group.md.erb
@@ -111,6 +111,13 @@ the Security Rules and Default Security Rules for unrestricted RDP access.
 
     it { should_not allow_rdp_from_internet }
 
+### allow\port\_from\_internet
+
+The allow\_port\_from\_internet property contains a boolean value determined by analysing
+the Security Rules and Default Security Rules for unrestricted access to a specified port.
+
+    it { should_not allow_port_from_internet('443') }
+
 ### Other Attributes
 
 There are additional attributes that may be accessed that we have not

--- a/libraries/azurerm_network_security_group.rb
+++ b/libraries/azurerm_network_security_group.rb
@@ -91,7 +91,7 @@ class AzurermNetworkSecurityGroup < AzurermSingularResource
 
     return properties['destinationPortRanges'] if !properties_hash.include?(:destinationPortRange)
 
-    properties['destinationPortRanges'].push(properties['destinationPortRange'])
+    properties['destinationPortRanges'] + Array(properties['destinationPortRange'])
   end
 
   def matches_port?(ports, match_port)

--- a/libraries/azurerm_network_security_group.rb
+++ b/libraries/azurerm_network_security_group.rb
@@ -88,7 +88,7 @@ class AzurermNetworkSecurityGroup < AzurermSingularResource
 
     ports.select { |port| port.include?('-') }
          .collect { |range| range.split('-') }
-         .any? { |range| (range.first..range.last).cover?(match_port) }
+         .any? { |range| (range.first.to_i..range.last.to_i).cover?(match_port.to_i) }
   end
 
   def tcp?(properties)

--- a/libraries/azurerm_network_security_group.rb
+++ b/libraries/azurerm_network_security_group.rb
@@ -44,15 +44,13 @@ class AzurermNetworkSecurityGroup < AzurermSingularResource
     @default_security_rules ||= @properties['defaultSecurityRules']
   end
 
-  SSH_CRITERIA = %i(ssh_port access_allow direction_inbound source_open).freeze
   def allow_ssh_from_internet?
-    @allow_ssh_from_internet ||= matches_criteria?(SSH_CRITERIA, security_rules_properties)
+    allow_port_from_internet?('22')
   end
   RSpec::Matchers.alias_matcher :allow_ssh_from_internet, :be_allow_ssh_from_internet
 
-  RDP_CRITERIA = %i(rdp_port access_allow direction_inbound source_open).freeze
   def allow_rdp_from_internet?
-    @allow_rdp_from_internet ||= matches_criteria?(RDP_CRITERIA, security_rules_properties)
+    allow_port_from_internet?('3389')
   end
   RSpec::Matchers.alias_matcher :allow_rdp_from_internet, :be_allow_rdp_from_internet
 
@@ -71,14 +69,6 @@ class AzurermNetworkSecurityGroup < AzurermSingularResource
 
   def matches_criteria?(criteria, properties)
     properties.any? { |property| criteria.all? { |method| send(:"#{method}?", property) } }
-  end
-
-  def ssh_port?(properties)
-    matches_port?(destination_port_ranges(properties), '22')
-  end
-
-  def rdp_port?(properties)
-    matches_port?(destination_port_ranges(properties), '3389')
   end
 
   def specific_port?(properties)

--- a/libraries/azurerm_network_security_group.rb
+++ b/libraries/azurerm_network_security_group.rb
@@ -44,19 +44,19 @@ class AzurermNetworkSecurityGroup < AzurermSingularResource
     @default_security_rules ||= @properties['defaultSecurityRules']
   end
 
-  SSH_CRITERIA = %i(ssh_port access_allow direction_inbound tcp source_open).freeze
+  SSH_CRITERIA = %i(ssh_port access_allow direction_inbound source_open).freeze
   def allow_ssh_from_internet?
     @allow_ssh_from_internet ||= matches_criteria?(SSH_CRITERIA, security_rules_properties)
   end
   RSpec::Matchers.alias_matcher :allow_ssh_from_internet, :be_allow_ssh_from_internet
 
-  RDP_CRITERIA = %i(rdp_port access_allow direction_inbound tcp source_open).freeze
+  RDP_CRITERIA = %i(rdp_port access_allow direction_inbound source_open).freeze
   def allow_rdp_from_internet?
     @allow_rdp_from_internet ||= matches_criteria?(RDP_CRITERIA, security_rules_properties)
   end
   RSpec::Matchers.alias_matcher :allow_rdp_from_internet, :be_allow_rdp_from_internet
 
-  SPECIFIC_CRITERIA = %i(specific_port access_allow direction_inbound tcp source_open).freeze
+  SPECIFIC_CRITERIA = %i(specific_port access_allow direction_inbound source_open).freeze
   def allow_port_from_internet?(specific_port)
     @specific_port = specific_port
     matches_criteria?(SPECIFIC_CRITERIA, security_rules_properties)

--- a/libraries/azurerm_network_security_group.rb
+++ b/libraries/azurerm_network_security_group.rb
@@ -92,7 +92,7 @@ class AzurermNetworkSecurityGroup < AzurermSingularResource
   end
 
   def tcp?(properties)
-    properties['protocol'].casecmp?('TCP')
+    properties['protocol'].match?(/TCP|\*/)
   end
 
   def access_allow?(properties)

--- a/libraries/azurerm_network_security_group.rb
+++ b/libraries/azurerm_network_security_group.rb
@@ -56,6 +56,13 @@ class AzurermNetworkSecurityGroup < AzurermSingularResource
   end
   RSpec::Matchers.alias_matcher :allow_rdp_from_internet, :be_allow_rdp_from_internet
 
+  SPECIFIC_CRITERIA = %i(specific_port access_allow direction_inbound tcp source_open).freeze
+  def allow_port_from_internet?(specific_port)
+    @specific_port = specific_port
+    matches_criteria?(SPECIFIC_CRITERIA, security_rules_properties)
+  end
+  RSpec::Matchers.alias_matcher :allow_port_from_internet, :be_allow_port_from_internet
+
   private
 
   def security_rules_properties
@@ -72,6 +79,10 @@ class AzurermNetworkSecurityGroup < AzurermSingularResource
 
   def rdp_port?(properties)
     matches_port?(destination_port_ranges(properties), '3389')
+  end
+
+  def specific_port?(properties)
+    matches_port?(destination_port_ranges(properties), @specific_port)
   end
 
   def destination_port_ranges(properties)

--- a/terraform/azure.tf
+++ b/terraform/azure.tf
@@ -189,16 +189,82 @@ resource "azurerm_network_security_group" "nsg" {
   name                = "Inspec-NSG"
   location            = var.location
   resource_group_name = azurerm_resource_group.rg.name
+}
 
+resource "azurerm_network_security_group" "nsg_insecure" {
+  name                = "Inspec-NSG-Insecure"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_network_security_rule" "SSHAllow" {
+  name                       = "SSH-Allow"
+  priority                   = 100
+  direction                  = "Inbound"
+  access                     = "Allow"
+  protocol                   = "*"
+  source_port_range          = "*"
+  destination_port_range     = "22"
+  source_address_prefix      = "*"
+  destination_address_prefix = "*"
+  resource_group_name        = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg_insecure.name
+}
+
+resource "azurerm_network_security_rule" "RDP-Allow" {
+  name                       = "RDP-Allow"
+  priority                   = 105
+  direction                  = "Inbound"
+  access                     = "Allow"
+  protocol                   = "*"
+  source_port_range          = "*"
+  destination_port_range     = "3389"
+  source_address_prefix      = "Internet"
+  destination_address_prefix = "*"
+  resource_group_name        = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg_insecure.name
+}
+
+resource "azurerm_network_security_rule" "DB-Allow" {
+  name                       = "DB-Allow"
+  priority                   = 110
+  direction                  = "Inbound"
+  access                     = "Allow"
+  protocol                   = "*"
+  source_port_range          = "*"
+  destination_port_ranges    = ["1433-1434", "1521", "4300-4350", "5000-6000"]
+  source_address_prefix      = "Internet"
+  destination_address_prefix = "*"
+  resource_group_name        = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg_insecure.name
+}
+
+resource "azurerm_network_security_rule" "File-Allow" {
+  name                       = "File-Allow"
+  priority                   = 120
+  direction                  = "Inbound"
+  access                     = "Allow"
+  protocol                   = "*"
+  source_port_range          = "*"
+  destination_port_ranges    = ["130-140", "445", "20-21", "69"]
+  source_address_prefix      = "0.0.0.0/0"
+  destination_address_prefix = "*"
+  resource_group_name        = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg_insecure.name
+}
+
+resource "azurerm_network_security_group" "nsg_open" {
+  name                = "Inspec-NSG-Open"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg.name
   security_rule {
-    name                       = "SSH-RDP-Deny"
+    name                       = "Open-All-To-World"
     priority                   = 100
     direction                  = "Inbound"
-    access                     = "Deny"
-    protocol                   = "Tcp"
+    access                     = "Allow"
+    protocol                   = "*"
     source_port_range          = "*"
-    destination_port_range     = ""
-    destination_port_ranges    = ["22", "3389"]
+    destination_port_range     = "*"
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -160,6 +160,14 @@ output "network_security_group_id" {
   value = azurerm_network_security_group.nsg.id
 }
 
+output "network_security_group_insecure" {
+  value = azurerm_network_security_group.nsg_insecure.name
+}
+
+output "network_security_group_open" {
+  value = azurerm_network_security_group.nsg_open.name
+}
+
 output "activity_log_alert_name" {
   value = var.activity_log_alert["log_alert"]
 }

--- a/test/integration/verify/controls/azurerm_network_security_group.rb
+++ b/test/integration/verify/controls/azurerm_network_security_group.rb
@@ -1,6 +1,8 @@
 resource_group = input('resource_group',            value: nil)
 nsg            = input('network_security_group',    value: nil)
 nsg_id         = input('network_security_group_id', value: nil)
+nsg_insecure   = input('network_security_group_insecure', value: nil)
+nsg_open       = input('network_security_group_open', value: nil)
 
 control 'azurerm_network_security_group' do
   describe azurerm_network_security_group(resource_group: resource_group, name: nsg) do
@@ -12,6 +14,38 @@ control 'azurerm_network_security_group' do
     its('default_security_rules') { should_not be_empty }
     it                            { should_not allow_rdp_from_internet }
     it                            { should_not allow_ssh_from_internet }
+    it                            { should_not allow_port_from_internet('1433') }
+    it                            { should_not allow_port_from_internet('1521') }
+    it                            { should_not allow_port_from_internet('4333') }
+    it                            { should_not allow_port_from_internet('5432') }
+    it                            { should_not allow_port_from_internet('139') }
+    it                            { should_not allow_port_from_internet('1433') }
+    it                            { should_not allow_port_from_internet('445') }
+    it                            { should_not allow_port_from_internet('1433') }
+    it                            { should_not allow_port_from_internet('21') }
+    it                            { should_not allow_port_from_internet('69') }
+  end
+
+  describe azurerm_network_security_group(resource_group: resource_group, name: nsg_insecure) do
+    it                            { should exist }
+    it                            { should allow_rdp_from_internet }
+    it                            { should allow_ssh_from_internet }
+    it                            { should allow_port_from_internet('1433') }
+    it                            { should allow_port_from_internet('1521') }
+    it                            { should allow_port_from_internet('4333') }
+    it                            { should allow_port_from_internet('5432') }
+    it                            { should allow_port_from_internet('139') }
+    it                            { should allow_port_from_internet('1433') }
+    it                            { should allow_port_from_internet('445') }
+    it                            { should allow_port_from_internet('1433') }
+    it                            { should allow_port_from_internet('21') }
+    it                            { should allow_port_from_internet('69') }
+  end
+
+  describe azurerm_network_security_group(resource_group: resource_group, name: nsg_open) do
+    it                            { should exist }
+    it                            { should allow_rdp_from_internet }
+    it                            { should allow_ssh_from_internet }
   end
 
   describe azurerm_network_security_group(resource_group: resource_group, name: 'fake') do


### PR DESCRIPTION
### Description

I need to write controls that match on arbitrary ports, not just SSH and RDP. 

Additionally:
- refactor the existing `allow_ssh_from_internet` and `allow_rdp_from_internet` matchers to use `allow_port_from_internet` underneath
- fix handling of port range(s) (port range and port ranges in the Azure API are strings - but we need integers in `matches_port?` to create the Ruby Range used to check if a port is included in a security rule)
- add better integration tests for security rules.

### Issues Resolved

Related: #243, #244 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
