### PR TITLE
Remove left-over folder created at `rake lint` task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,9 +53,9 @@ namespace :syntax do
   desc 'InSpec syntax check'
   task :inspec do
     puts '-> Checking Inspec Control Syntax'
-    stdout, status = Open3.capture2("./bin/inspec vendor #{INTEGRATION_DIR} --overwrite &&
-                                     ./bin/inspec check #{INTEGRATION_DIR} &&
-                                     ./bin/inspec check .")
+    stdout, status = Open3.capture2("bundle exec inspec vendor #{INTEGRATION_DIR} --overwrite &&
+                                     bundle exec inspec check #{INTEGRATION_DIR} &&
+                                     bundle exec inspec check . && rm -rf #{INTEGRATION_DIR}/vendor")
     puts stdout
 
     %w{errors}.each do |type|


### PR DESCRIPTION

Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

`rake lint` runs `inspec vendor` command before syntax check and this creates a `vendor` folder with the dependencies in it.
A second `rake lint` task detects the style issues in the `vendor` file and fails the `lint` task.
It should be removed after syntax check.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
