### PR TITLE
Add `tags` property to the azurerm_load_balancer resource

### DIFF
--- a/docs/resources/azurerm_load_balancers.md
+++ b/docs/resources/azurerm_load_balancers.md
@@ -94,7 +94,6 @@ Filters the results to include only those load balancers which reside in a given
 - `sku`
 - `location`
 - `properties`
-- `tags`
 - `type`
     
 ### ids
@@ -115,9 +114,6 @@ Resource location, e.g. `eastus`.
 
 ### properties
 A collection of additional configuration properties related to the Load Balancer, e.g. `loadBalancingRules`.
-
-### tag
-Resource tags applied to the Load balancer.
 
 ### type
 The type of Resource, typically `Microsoft.Network/loadBalancers`.

--- a/libraries/azurerm_load_balancer.rb
+++ b/libraries/azurerm_load_balancer.rb
@@ -18,6 +18,7 @@ class AzurermLoadBalancer < AzurermSingularResource
     type
     sku
     properties
+    tags
   ).freeze
 
   attr_reader(*ATTRS)

--- a/libraries/azurerm_load_balancers.rb
+++ b/libraries/azurerm_load_balancers.rb
@@ -20,7 +20,6 @@ class AzurermLoadBalancers < AzurermPluralResource
              .register_column(:skus,       field: :sku)
              .register_column(:locations,  field: :location)
              .register_column(:properties, field: :properties)
-             .register_column(:tags,       field: :tag)
              .register_column(:types,      field: :type)
              .install_filter_methods_on_resource(self, :table)
 


### PR DESCRIPTION
Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

- Ad `tags` property to the singular resource `azurerm_load_balancer`.
- Remove broken `tags` property from plural `azurerm_load_balancers`.

### Issues Resolved

Fixes #260 

### Check List

- [x] New functionality includes tests
- [ ] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
