### PR TITLE
Make HDINSIGHT integration tests optional due to resource constraint

### DIFF
--- a/terraform/azure.tf
+++ b/terraform/azure.tf
@@ -711,6 +711,7 @@ resource "azurerm_kubernetes_cluster" "cluster" {
 
 
 resource "azurerm_storage_account" "hdinsight_storage_account" {
+  count                    = var.hd_insight_count
   name                     = "hdinsight${random_string.storage_account.result}"
   resource_group_name      = azurerm_resource_group.rg.name
   location                 = azurerm_resource_group.rg.location
@@ -719,13 +720,15 @@ resource "azurerm_storage_account" "hdinsight_storage_account" {
 }
 
 resource "azurerm_storage_container" "hdinsight_storage_container" {
-  name = "hdinsight${random_string.storage_account.result}"
-  storage_account_name  = azurerm_storage_account.hdinsight_storage_account.name
+  count                 = var.hd_insight_count
+  name                  = "hdinsight${random_string.storage_account.result}"
+  storage_account_name  = azurerm_storage_account.hdinsight_storage_account[0].name
   container_access_type = "private"
 }
 
 resource "azurerm_hdinsight_interactive_query_cluster" "hdinsight_cluster" {
-  name = "hdinsight6fbw66f8ch"
+  count               = var.hd_insight_count
+  name                = "hdinsight6fbw66f8ch"
   resource_group_name = azurerm_resource_group.rg.name
   location            = azurerm_resource_group.rg.location
   cluster_version     = "4.0"
@@ -742,8 +745,8 @@ resource "azurerm_hdinsight_interactive_query_cluster" "hdinsight_cluster" {
   }
 
   storage_account {
-    storage_container_id = azurerm_storage_container.hdinsight_storage_container.id
-    storage_account_key  = azurerm_storage_account.hdinsight_storage_account.primary_access_key
+    storage_container_id = azurerm_storage_container.hdinsight_storage_container[0].id
+    storage_account_key  = azurerm_storage_account.hdinsight_storage_account[0].primary_access_key
     is_default           = true
   }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -313,5 +313,5 @@ output "application_gateway_name" {
 
 output "hdinsight_cluster_name" {
   description = "HDINSIGHT cluster name."
-  value       = azurerm_hdinsight_interactive_query_cluster.hdinsight_cluster.name
+  value = var.hd_insight_count > 0 ? azurerm_hdinsight_interactive_query_cluster.hdinsight_cluster.0.name : ""
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -94,3 +94,8 @@ variable "lb_port" {
     http-test = ["990", "Tcp", "990", "SourceIPProtocol"]
   }
 }
+
+variable "hd_insight_count" {
+  # This is added due to resource constraints.
+  default = 0
+}

--- a/test/integration/verify/controls/azurerm_hdinsight_cluster.rb
+++ b/test/integration/verify/controls/azurerm_hdinsight_cluster.rb
@@ -1,8 +1,8 @@
 resource_group = input('resource_group', value: nil)
-cluster_name = input('hdinsight_cluster_name', value: nil)
+cluster_name = input('hdinsight_cluster_name', value: '')
 
 control 'azurerm_hdinsight_cluster' do
-  only_if { ENV['HDINSIGHT'] }
+  only_if { !cluster_name.empty? }
   describe azurerm_hdinsight_cluster(resource_group: resource_group, name: cluster_name) do
     it                                                       { should exist }
     its('name')                                              { should cmp cluster_name }

--- a/test/integration/verify/controls/azurerm_hdinsight_cluster.rb
+++ b/test/integration/verify/controls/azurerm_hdinsight_cluster.rb
@@ -2,6 +2,7 @@ resource_group = input('resource_group', value: nil)
 cluster_name = input('hdinsight_cluster_name', value: nil)
 
 control 'azurerm_hdinsight_cluster' do
+  only_if { ENV['HDINSIGHT'] }
   describe azurerm_hdinsight_cluster(resource_group: resource_group, name: cluster_name) do
     it                                                       { should exist }
     its('name')                                              { should cmp cluster_name }


### PR DESCRIPTION
Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

Make HdInsight integration tests optional due to resource constraints.

### Issues Resolved

Fix CI tests.

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
