### PR TITLE
Fix resource_provider issue in generic_resource

### DIFF
--- a/libraries/azure_generic_resource.rb
+++ b/libraries/azure_generic_resource.rb
@@ -165,23 +165,23 @@ class AzureGenericResource < AzureResourceBase
           filter[:resource_type] = filter[:resource_provider] unless filter[:resource_provider].nil?
           filter.delete(:resource_provider)
           @resources = resource_short(filter)
+          # If an exception is raised above then the resource is failed.
+          # This check should be done every time after using catch_failed_resource_queries
+          #
+          return if failed_resource?
+
+          # Validate short description whether:
+          # There is a resource description? (0: it should_not exist, nil: fail resource)
+          # There are multiple resource description? (fail resource for singular resource)
+          #
+          validated = validate_short_desc(@resources, filter, true)
+          # If resource description is not in expected format, resource will be failed here.
+          return unless validated
+
+          # For a singular resource there must be one and only resource description with a resource_id.
+          @resource_id = @resources.first[:id]
         end
       end
-      # If an exception is raised above then the resource is failed.
-      # This check should be done every time after using catch_failed_resource_queries
-      #
-      return if failed_resource?
-
-      # Validate short description whether:
-      # There is a resource description? (0: it should_not exist, nil: fail resource)
-      # There are multiple resource description? (fail resource for singular resource)
-      #
-      validated = validate_short_desc(@resources, filter, true)
-      # If resource description is not in expected format, resource will be failed here.
-      return unless validated
-
-      # For a singular resource there must be one and only resource description with a resource_id.
-      @resource_id = @resources.first[:id]
     end
   end
 end

--- a/test/integration/verify/controls/azure_generic_resource.rb
+++ b/test/integration/verify/controls/azure_generic_resource.rb
@@ -20,6 +20,10 @@ control 'azure_generic_resource' do
     its('name') { should eq win_name }
   end
 
+  describe azure_generic_resource(resource_provider: 'Microsoft.Compute/virtualMachines', resource_group: resource_group, name: win_name) do
+    it { should exist }
+  end
+
   # If api_version is not provided, latest version should be used.
   describe azure_generic_resource(resource_group: resource_group, name: win_name) do
     its('api_version_used_for_query_state') { should eq 'latest' }


### PR DESCRIPTION
Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

`azure_generic_resource` is not functioning as intended when the `resource_provider` parameter is used.

### Issues Resolved

Fixes #302 

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
