### PR TITLE
Move credential checks into the AzureConnection#authenticate

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,11 +52,6 @@ end
 namespace :syntax do
   desc 'InSpec syntax check'
   task :inspec do
-    puts '-> Checking The Environment Variables: Assigning placeholders if they are not defined.'
-    ENV['AZURE_SUBSCRIPTION_ID'] = 'placeHolder' unless ENV['AZURE_SUBSCRIPTION_ID']
-    ENV['AZURE_CLIENT_ID'] = 'placeHolder' unless ENV['AZURE_CLIENT_ID']
-    ENV['AZURE_TENANT_ID'] = 'placeHolder' unless ENV['AZURE_TENANT_ID']
-    ENV['AZURE_CLIENT_SECRET'] = 'placeHolder' unless ENV['AZURE_CLIENT_SECRET']
     puts '-> Checking InSpec Control Syntax'
     stdout, status = Open3.capture2("bundle exec inspec vendor #{INTEGRATION_DIR} --overwrite --chef-license accept-silent &&
                                      bundle exec inspec check #{INTEGRATION_DIR}")
@@ -103,23 +98,15 @@ namespace :azure do
   end
 end
 
-# Minitest
-Rake::TestTask.new(:unit) do |t|
-  t.libs << 'test/unit'
-  t.libs << 'libraries'
-  t.verbose = true
-  t.warning = false
-  t.test_files = FileList['test/unit/**/*_test.rb']
-end
-
 namespace :test do
 
-  task :unit do
-    ENV['AZURE_SUBSCRIPTION_ID'] = 'placeHolder' unless ENV['AZURE_SUBSCRIPTION_ID']
-    ENV['AZURE_CLIENT_ID'] = 'placeHolder' unless ENV['AZURE_CLIENT_ID']
-    ENV['AZURE_TENANT_ID'] = 'placeHolder' unless ENV['AZURE_TENANT_ID']
-    ENV['AZURE_CLIENT_SECRET'] = 'placeHolder' unless ENV['AZURE_CLIENT_SECRET']
-    Rake::Task['unit'].execute
+  # Minitest
+  Rake::TestTask.new(:unit) do |t|
+    t.libs << 'test/unit'
+    t.libs << 'libraries'
+    t.verbose = true
+    t.warning = false
+    t.test_files = FileList['test/unit/**/*_test.rb']
   end
 
   task :integration, [:controls] => ['attributes:write', :setup_env] do |_t, args|

--- a/libraries/azure_backend.rb
+++ b/libraries/azure_backend.rb
@@ -46,12 +46,8 @@ class AzureResourceBase < Inspec.resource(1)
     # Fail resource if the http client is not properly set up.
     begin
       @azure = AzureConnection.new(@client_args)
-    rescue HTTPClientError::MissingCredentials => e
-      message = "HTTP Client Error.\n#{e.message}"
-      resource_fail(message)
-      raise HTTPClientError, message
     rescue StandardError => e
-      message = "Resource is failed due to #{e}"
+      message = "HTTP client is failed due to #{e}"
       resource_fail(message)
       raise StandardError, message
     end

--- a/libraries/backend/azure_connection.rb
+++ b/libraries/backend/azure_connection.rb
@@ -121,7 +121,7 @@ class AzureConnection
     unless @credentials.values.compact.delete_if(&:empty?).size == 4
       raise HTTPClientError::MissingCredentials, 'The following must be set in the Environment:'\
         " #{@credentials.keys}.\n"\
-        "Provided: #{@credentials}"
+        "Missing: #{@credentials.keys.select { |key| @credentials[key].nil? }}"
     end
     # Build up the url that is required to authenticate with Azure REST API
     auth_url = "#{@client_args[:endpoint].active_directory_endpoint_url}#{@credentials[:tenant_id]}/oauth2/token"

--- a/libraries/backend/azure_connection.rb
+++ b/libraries/backend/azure_connection.rb
@@ -57,12 +57,6 @@ class AzureConnection
       client_secret: ENV['AZURE_CLIENT_SECRET'],
       subscription_id: ENV['AZURE_SUBSCRIPTION_ID'],
     }
-    # Validate the presence of credentials.
-    unless @credentials.values.compact.delete_if(&:empty?).size == 4
-      raise HTTPClientError::MissingCredentials, 'The following must be set in the Environment:'\
-        " #{@credentials.keys}.\n"\
-        "Provided: #{@credentials}"
-    end
 
     @connection ||= Faraday.new do |conn|
       # Implement user provided HTTP client params for handling TimeOut exceptions.
@@ -123,6 +117,12 @@ class AzureConnection
   # https://docs.microsoft.com/en-us/rest/api/azure/
   #
   def authenticate(resource)
+    # Validate the presence of credentials.
+    unless @credentials.values.compact.delete_if(&:empty?).size == 4
+      raise HTTPClientError::MissingCredentials, 'The following must be set in the Environment:'\
+        " #{@credentials.keys}.\n"\
+        "Provided: #{@credentials}"
+    end
     # Build up the url that is required to authenticate with Azure REST API
     auth_url = "#{@client_args[:endpoint].active_directory_endpoint_url}#{@credentials[:tenant_id]}/oauth2/token"
     body = {

--- a/test/integration/verify/controls/azurerm_resource_groups.rb
+++ b/test/integration/verify/controls/azurerm_resource_groups.rb
@@ -1,9 +1,13 @@
 resource_group = input('resource_group', value: nil)
 
+# Added to test `inspec check` command
+resource_group_names = azure_resource_groups.names
+
 control 'azurerm_resource_groups' do
   describe azurerm_resource_groups do
-    it                 { should exist }
-    its('names')       { should include(resource_group) }
+    it { should exist }
+    its('names') { should include(resource_group) }
+    its('names.size') { should eq resource_group_names.size }
   end
 
   describe azurerm_resource_groups.where(name: resource_group) do


### PR DESCRIPTION
Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

- Move credential checks into the `AzureConnection#authenticate` method to enable `inspec check` pass
- Update Rakefile regarding the credential checks
- Fix `azure_resource_group#to_s` method

### Issues Resolved

Fixes #312 

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
