### PR TITLE
Adding subscription level check for diagnostic settings

### DIFF
--- a/docs/resources/azure_subscription.md
+++ b/docs/resources/azure_subscription.md
@@ -64,6 +64,9 @@ end
 | logical_locations         | The list of all available geo-location names that have the `metadata.regionType` is set to `Logical`. |
 | locations_list            | The list of all available geo-location objects in [this](https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/listlocations#location) format. |
 | managedByTenants          | An array containing the [tenants](https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/get#managedbytenant) managing the subscription. |
+| diagnostic_settings                  | The diagnostic settings set at a subcription level. |
+| diagnostic_settings_enabled_logging  | The enabled logging types from diagnostic settings set at a subcription level.  |
+| diagnostic_settings_disabled_logging | The disabled logging types from diagnostic settings set at a subcription level. |
 
 <superscript>*</superscript> `physical_locations` might be different than the `locations` property depending on the api version.
 This is because of the change in the Azure API terminology. It is advised to see the [official documentation](https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/listlocations) for more info.
@@ -93,6 +96,18 @@ describe azure_subscription do
   its('locations') { should include('eastus') }
 end
 ```    
+### Test Your Subscription`s enabled logging types (via diagnostic settings)
+```ruby
+describe azure_subscription do
+  its('diagnostic_settings_enabled_logging_types') { should include('ResourceHealth') }
+end
+```  
+### Test Your Subscription`s disabled logging types (via diagnostic settings)
+```ruby
+describe azure_subscription do
+  its('diagnostic_settings_disabled_logging_types') { should include('Recommendation') }
+end
+```  
 ## Matchers
 
 This InSpec audit resource has the following special matchers. For a full list of available matchers, please visit our [Universal Matchers page](https://www.inspec.io/docs/reference/matchers/).

--- a/libraries/azure_subscription.rb
+++ b/libraries/azure_subscription.rb
@@ -94,7 +94,7 @@ class AzureSubscription < AzureGenericResource
       result.push setting.name
     end
     result
-  end 
+  end
 
   def diagnostic_settings_locations
     return nil if diagnostic_settings.first.nil?
@@ -112,7 +112,7 @@ class AzureSubscription < AzureGenericResource
       result.push setting.properties.eventHubName
     end
     result
-  end 
+  end
 
   def diagnostic_settings_enabled_logging_types
     return nil if diagnostic_settings.first.nil?

--- a/libraries/azure_subscription.rb
+++ b/libraries/azure_subscription.rb
@@ -76,6 +76,62 @@ class AzureSubscription < AzureGenericResource
     locations_list.select { |location| location.metadata&.regionType == 'Logical' }.map(&:name)
   end
 
+  def diagnostic_settings
+    return unless exists?
+    additional_resource_properties(
+      {
+        property_name: 'default',
+        property_endpoint: 'subscriptions/' + id + '/providers/microsoft.insights/diagnosticSettings',
+        api_version: '2017-05-01-preview',
+      },
+    )
+  end
+
+  def diagnostic_settings_names
+    return nil if diagnostic_settings.first.nil?
+    result = []
+    diagnostic_settings.each do |setting|
+      result.push setting.name
+    end
+    result
+  end 
+
+  def diagnostic_settings_locations
+    return nil if diagnostic_settings.first.nil?
+    result = []
+    diagnostic_settings.each do |setting|
+      result.push setting.location
+    end
+    result
+  end
+
+  def diagnostic_settings_event_hubs
+    return nil if diagnostic_settings.first.nil?
+    result = []
+    diagnostic_settings.each do |setting|
+      result.push setting.properties.eventHubName
+    end
+    result
+  end 
+
+  def diagnostic_settings_enabled_logging_types
+    return nil if diagnostic_settings.first.nil?
+    result = []
+    diagnostic_settings.each do |setting|
+      result += setting.properties.logs.select(&:enabled).map(&:category)
+    end
+    result
+  end
+
+  def diagnostic_settings_disabled_logging_types
+    return nil if diagnostic_settings.first.nil?
+    result = []
+    diagnostic_settings.each do |setting|
+      result += setting.properties.logs.reject(&:enabled).map(&:category)
+    end
+    result
+  end
+
   private
 
   def fetch_locations

--- a/libraries/azure_subscription.rb
+++ b/libraries/azure_subscription.rb
@@ -109,7 +109,7 @@ class AzureSubscription < AzureGenericResource
     return nil if diagnostic_settings.first.nil?
     result = []
     diagnostic_settings.each do |setting|
-      result.push setting.properties.eventHubName
+      result.push setting.properties&.eventHubName
     end
     result
   end
@@ -118,7 +118,7 @@ class AzureSubscription < AzureGenericResource
     return nil if diagnostic_settings.first.nil?
     result = []
     diagnostic_settings.each do |setting|
-      result += setting.properties.logs.select(&:enabled).map(&:category)
+      result += setting.properties&.logs&.select(&:enabled)&.map(&:category)
     end
     result
   end
@@ -127,7 +127,7 @@ class AzureSubscription < AzureGenericResource
     return nil if diagnostic_settings.first.nil?
     result = []
     diagnostic_settings.each do |setting|
-      result += setting.properties.logs.reject(&:enabled).map(&:category)
+      result += setting.properties&.logs&.reject(&:enabled)&.map(&:category)
     end
     result
   end


### PR DESCRIPTION
### Description

Adding in a number of new attributes for the azure_subscription resource in order to allow checks for configuration of the diagnostic settings.

### Issues Resolved

#321 

### Check List

- [ ] New functionality includes tests
- [✓] All tests pass
- [✓] `rake lint` passes
- [✓] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
