### PR TITLE
Compare the contents of AzureResourceProbe objects with eql? method

### DIFF
--- a/libraries/azure_backend.rb
+++ b/libraries/azure_backend.rb
@@ -678,6 +678,25 @@ class AzureResourceProbe
     @item.key?(opt.to_sym)
   end
 
+  # Resource prob holds the data in the @item attribute.
+  # Compare the other item with it.
+  def eql?(other)
+    literal = other == @item
+    return literal if literal
+    # If the other item is a Hash and its keys are in String format, convert them to symbol and then compare.
+    if other.class == Hash and @item.class == Hash
+      if other.keys.first.class == String
+        hash_with_sym_keys = RecursiveMethodHelper.method_recursive(other, :to_sym)
+        return hash_with_sym_keys == @item
+      else
+        super
+      end
+    else
+      super
+    end
+    super
+  end
+
   # Prevent undefined method error by returning nil.
   # This will prevent breaking a test when queried a non-existing method.
   # @return [NilClass]


### PR DESCRIPTION
Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

- Compare AzureResourceProbe objects' contents with the `eql?` method.
This will allow:
```
describe azure_virtual_machine(resource_id: '/foo/bar') do
   its('tags') { should eql({'name': 'my_VM'})
end
```

### Issues Resolved

Fixes #326 

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
