### PR TITLE
Remove 2.5 from pipeline verification

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,14 +1,6 @@
 ---
 steps:
 
-- label: run-tests-ruby-2.5
-  command:
-    - /workdir/.expeditor/buildkite/verify.sh
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.5-stretch
-
 - label: run-tests-ruby-2.6
   command:
     - /workdir/.expeditor/buildkite/verify.sh


### PR DESCRIPTION
Signed-off-by: Omer Demirok <odemirok@chef.io>

### Description

- chef-core deprecated supporting Ruby version **2.5**: https://github.com/chef/chef/issues/10698
- This change will remove **2.5** from pipeline verification.

### Issues Resolved

Resolves #340 

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [ ] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
