### PR TITLE
Allow dependabot to check ruby gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Description

This change allows dependabot to check ruby related dependencies which this project uses and automatically submit PRs with version bumps in order to keep packages up-to-date. Below is a link to dependabot's documentation.

https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates

### Issues Resolved

There aren't any related issues that I know of.

### Check List

I believe apart of PRs, GitHub has a feature where there's a dependabot validator which checks to make sure dependabot configuration files are syntactically correct.

I'm not too sure if the boxes left unchecked are related to this type of change.

- [x] New functionality includes tests
- [ ] All tests pass
- [ ] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
