### PR TITLE
Add docs team to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 # Order is important. The last matching pattern has the most precedence.
 
 *             @inspec/inspec-cloud-devs
+docs/**       @inspec/inspec-cloud-devs @inspec/docs-team


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <Ian.Maddaus@progress.com>

### Description

Add docs team to codeowners so we get notified of changes to resource docs.

### Issues Resolved

chef/chef-web-docs#3060

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
