### PR TITLE
Add support for testing Azure Policy Assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ The following is a list of static resources.
 - [azure_network_security_groups](docs/resources/azure_network_security_groups.md)
 - [azure_network_watcher](docs/resources/azure_network_watcher.md)
 - [azure_network_watchers](docs/resources/azure_network_watchers.md)
+- [azure_policy_assignments](docs/resources/azure_policy_assignments.md)
 - [azure_policy_definition](docs/resources/azure_policy_definition.md)
 - [azure_policy_definitions](docs/resources/azure_policy_definitions.md)
 - [azure_postgresql_database](docs/resources/azure_postgresql_database.md)

--- a/docs/resources/azure_policy_assignments.md
+++ b/docs/resources/azure_policy_assignments.md
@@ -1,0 +1,72 @@
+---
+title: About the azure_policy_assignments Resource
+platform: azure
+---
+
+## azure_policy_assignments
+
+Use the `azure_policy_assignments` InSpec resource to examine assignments of Azure policy to resources and resource groups.
+
+## Azure REST API version, endpoint and http client parameters
+
+This resource interacts with api versions supported by the resource provider.
+The `api_version` can be defined as a resource parameter.
+If not provided, the latest version will be used.
+For more information, refer to [`azure_generic_resource`](azure_generic_resource.md).
+
+Unless defined, `azure_cloud` global endpoint, and default values for the http client will be used.
+For more information, refer to the resource pack [README](../../README.md).
+
+### Installation
+
+This resource is available in the [InSpec Azure resource pack](https://github.com/inspec/inspec-azure).
+For an example `inspec.yml` file and how to set up your Azure credentials, refer to resource pack [README](../../README.md#Service-Principal).
+
+## Syntax
+
+```ruby
+describe azure_policy_assignments do
+  it { should exist }
+end
+```
+
+```ruby
+describe azure_policy_assignments.where{ enforcement_mode != 'Default' } do
+    it {should_not exist}
+    its('display_names') {should eq []}
+end
+```
+
+## Properties
+
+Please review the [Azure documentation](https://docs.microsoft.com/en-us/rest/api/policy/policyassignments/list#policyassignment) for a full description of properties.
+
+| Property                | Filter           | Description                                                                              |
+|-------------------------|------------------|------------------------------------------------------------------------------------------|
+| ids                     | id               | The identity of the policy assignment (this is not the identity of the policy itself)    |
+| identities              | identity         | The managed identity associated with the policy assignment.                              |
+| locations               | location         | The location of the policy assignment. Only used when utilizing managed identity.        |
+| names                   | name             | The name of the policy assignment                                                        |
+| descriptions            | description      | This message will be part of response in case of policy violation.                       |
+| display_names           | display_name     | The display name of the policy assignment.                                               |
+| excluded_scopes         | excluded_scopes  | The scopes (resources/groups) which are excluded from this policy assignment             |
+| enforcement_modes       | enforcement_mode | The policy assignment enforcement mode. Possible values are `Default` and `DoNotEnforce` |
+| non_compliance_messages | non_compliance_messages | The messages that describe why a resource is non-compliant with the policy.       |
+| parameters              | parameters       | Additional parameters                                                                    |
+| definition_ids          | definition_id    | The ID of the policy that this assignment refers to                                      |
+| scopes                  | scope            | The scope of the policy assignment                                                       |
+
+## Examples
+
+Check that all assigned policies are in enforcing mode
+
+```ruby
+describe azure_policy_assignments.where{ enforcement_mode == 'DoNotEnforce' } do
+    it {should_not exist}
+    its('display_names') {should eq []}
+end
+```
+
+## Azure Permissions
+
+Your [Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal) must be setup with a `contributor` role on the subscription you wish to test.

--- a/docs/resources/azure_policy_assignments.md
+++ b/docs/resources/azure_policy_assignments.md
@@ -30,31 +30,32 @@ describe azure_policy_assignments do
 end
 ```
 
-```ruby
-describe azure_policy_assignments.where{ enforcement_mode != 'Default' } do
-    it {should_not exist}
-    its('display_names') {should eq []}
-end
-```
-
 ## Properties
 
 Please review the [Azure documentation](https://docs.microsoft.com/en-us/rest/api/policy/policyassignments/list#policyassignment) for a full description of properties.
 
-| Property                | Filter           | Description                                                                              |
-|-------------------------|------------------|------------------------------------------------------------------------------------------|
-| ids                     | id               | The identity of the policy assignment (this is not the identity of the policy itself)    |
-| identities              | identity         | The managed identity associated with the policy assignment.                              |
-| locations               | location         | The location of the policy assignment. Only used when utilizing managed identity.        |
-| names                   | name             | The name of the policy assignment                                                        |
-| descriptions            | description      | This message will be part of response in case of policy violation.                       |
-| display_names           | display_name     | The display name of the policy assignment.                                               |
-| excluded_scopes         | excluded_scopes  | The scopes (resources/groups) which are excluded from this policy assignment             |
-| enforcement_modes       | enforcement_mode | The policy assignment enforcement mode. Possible values are `Default` and `DoNotEnforce` |
-| non_compliance_messages | non_compliance_messages | The messages that describe why a resource is non-compliant with the policy.       |
-| parameters              | parameters       | Additional parameters                                                                    |
-| definition_ids          | definition_id    | The ID of the policy that this assignment refers to                                      |
-| scopes                  | scope            | The scope of the policy assignment                                                       |
+| Property             | Filter              | Description                                                                              |
+|----------------------|---------------------|------------------------------------------------------------------------------------------|
+| ids                  | id                  | The ID of this policy assignment                                                         |
+| types                | type                | The Azure resource type                                                                  |
+| names                | name                | The names of the policy assignments                                                      |
+| locations            | location            | The locations of the policy assignments                                                  |
+| tags                 | tags                | The tags of the policy assignments                                                       |
+| displayNames         | displayName         | The display names of the policy assignments                                              |
+| policyDefinitionIds  | policyDefinitionId  | The IDs of the policies being assigned by these policy assignments                       |
+| scopes               | scope               | The scope of the policy assignments (which resources they are being attached to)         |
+| notScopes            | notScopes           | The scopes which are excluded from these policy assignments (blocks inheritance)         |
+| parameters           | parameters          | The override parameters passed to the base policy by this assignment                     |
+| enforcementMode      | enforcementModes    | The enforment modes of these policy assignments                                          |
+| assignedBys          | assignedBy          | The ID's that assigned these policies                                                    |
+| parameterScopes      | parameterScopes     | Unknown - no data observed in this field in the wild                                     |
+| created_bys          | created_by          | The ID's that created these policy assignments                                           |
+| createdOns           | createdOn           | The dates these policy assignments were created (as a ruby Time object)                  |
+| updatedBys           | updatedBy           | The ID's that updated these policy assignments                                           |
+| updatedOns           | updatedOn           | The dates these policy assignments were updated (as a ruby Time object)                  |
+| identityPrincipalIds | identityPrincipalId | The principal ID's of the associated managed identities                                  |
+| identityTenantIds    | identityTenantId    | The tenant ID's of the associated managed identities                                     |
+| identityTypes        | identityType        | The identity types of the associated managed identities                                  |
 
 ## Examples
 
@@ -64,6 +65,17 @@ Check that all assigned policies are in enforcing mode
 describe azure_policy_assignments.where{ enforcement_mode == 'DoNotEnforce' } do
     it {should_not exist}
     its('display_names') {should eq []}
+end
+```
+
+Check that no policies were modified in the last 30 days
+
+```ruby
+last_30_days = Time.now() - (60*60*24*30)
+
+describe azure_policy_assignments.where{ (updatedOn > last_30_days) || (createdOn > last_30_days) } do
+  it {should_not exist}
+  its('ids') {should eq []}
 end
 ```
 

--- a/libraries/azure_policy_assignments.rb
+++ b/libraries/azure_policy_assignments.rb
@@ -1,0 +1,72 @@
+require 'azure_generic_resources'
+
+class AzurePolicyAssignments < AzureGenericResources
+  name 'azure_policy_assignments'
+  desc 'Verifies settings for a collection of policy assignments'
+  example <<-EXAMPLE
+    # For property names see https://docs.microsoft.com/en-us/rest/api/policy/policyassignments/list#policyassignment
+
+    describe azure_policy_assignments.where{ enforcement_mode != 'Default' } do
+        it {should_not exist}
+        its('display_names') {should eq []}
+    end
+  EXAMPLE
+
+  attr_reader :table
+
+  def initialize(opts = {})
+    # Options should be Hash type. Otherwise Ruby will raise an error when we try to access the keys.
+    raise ArgumentError, 'Parameters must be provided in an Hash object.' unless opts.is_a?(Hash)
+
+    # Azure REST API endpoint URL format listing the all resources for a given subscription:
+    #   GET https://management.azure.com/subscriptions/{subscriptionId}/providers/{resourceProvider}
+    #   Our resourceProvider is Microsoft.Authorization/policyAssignments
+    opts[:resource_provider] = specific_resource_constraint('Microsoft.Authorization/policyAssignments', opts)
+
+    # static_resource parameter must be true for setting the resource_provider in the backend.
+    super(opts, true)
+
+    # Check if the resource is failed.
+    # It is recommended to check that after every usage of inherited methods or making API calls.
+    return if failed_resource?
+
+    AzurePolicyAssignments.populate_filter_table(:table)
+  end
+
+  # Define the column and field names for FilterTable.
+  # In most cases, the `column` should be the pluralized form of the `field`.
+  # @see https://github.com/inspec/inspec/blob/master/docs/dev/filtertable-usage.md
+  def self.populate_filter_table(raw_data)
+    # Top level fields
+    filter_table = FilterTable.create
+    filter_table.register_column(:ids,          field: :id)
+    filter_table.register_column(:identities,   field: :identity)
+    filter_table.register_column(:locations,    field: :location)
+    filter_table.register_column(:names,        field: :name)
+    filter_table.register_column(:types,        field: :type)
+    filter_table.register_column(:properties,   field: :properties)
+
+    # Sub fields are registered with blocks instead of top level field names
+    filter_table.register_column(:descriptions)       { |p| p.entries.map { |e| e.dig(:properties, :description) } }
+    filter_table.register_column(:display_names)      { |p| p.entries.map { |e| e.dig(:properties, :displayName) } }
+    filter_table.register_column(:enforcement_modes)  { |p| p.entries.map { |e| e.dig(:properties, :enforcementMode) } }
+    filter_table.register_column(:meta_datas)         { |p| p.entries.map { |e| e.dig(:properties, :metadata) } }
+    filter_table.register_column(:non_compliance_messages) { |p| p.entries.map { |e| e.dig(:properties, :nonComplianceMessages) } }
+    filter_table.register_column(:excluded_scopes)    { |p| p.entries.map { |e| e.dig(:properties, :notScopes) } }
+    filter_table.register_column(:parameters)         { |p| p.entries.map { |e| e.dig(:properties, :parameters) } }
+    filter_table.register_column(:definition_ids)     { |p| p.entries.map { |e| e.dig(:properties, :policyDefinitionId) } }
+    filter_table.register_column(:scopes)             { |p| p.entries.map { |e| e.dig(:properties, :scope) } }
+    filter_table.register_column(:assigned_by)        { |p| p.entries.map { |e| e.dig(:properties, :metadata, :assignedBy) } }
+    filter_table.register_column(:created_by)         { |p| p.entries.map { |e| e.dig(:properties, :metadata, :createdBy) } }
+    filter_table.register_column(:created_on)         { |p| p.entries.map { |e| e.dig(:properties, :metadata, :createdOn) } }
+    filter_table.register_column(:updated_by)         { |p| p.entries.map { |e| e.dig(:properties, :metadata, :updatedBy) } }
+    filter_table.register_column(:updated_on)         { |p| p.entries.map { |e| e.dig(:properties, :metadata, :updatedOn) } }
+
+    # Connect the filter table to the data
+    filter_table.install_filter_methods_on_resource(self, raw_data)
+  end
+
+  def to_s
+    'AzurePolicyAssignments'
+  end
+end

--- a/test/integration/verify/controls/azure_policy_assignments.rb
+++ b/test/integration/verify/controls/azure_policy_assignments.rb
@@ -1,0 +1,11 @@
+control 'azure_policy_assignments' do
+  title 'azure_policy_assignments tests'
+  desc  'azure_policy_assignments tests'
+  impact 0.7
+
+  describe azure_policy_assignments do
+    it { should exist }
+    its('names.class') { should eq 'Array' }
+    its('displayNames.class') { should eq 'Array' }
+  end
+end


### PR DESCRIPTION
Signed-off-by: Richard Nixon <richard.nixon@btinternet>

### Description

Add support for testing Azure Policy Assignments.
In particular, allow modification times to be compared using ruby `Time` classes.

### Issues Resolved

No issues resolved, but this PR expands our testing capabilities for Azure policy as requested by a large EMEA customer in the banking sector.

### Check List

- [Y] New functionality includes tests
- [Y] All tests pass
- [Y] `rake lint` passes
- [Y] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
