### PR TITLE
Updating expeditor configuration

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -14,7 +14,8 @@ github:
  minor_bump_labels:
   - "Version: Bump Minor"
  version_tag_format: v{{version}}
- release_branch:
+ 
+release_branches:
   - master
  
 changelog:
@@ -24,15 +25,17 @@ changelog:
   - "Type: Enhancement": "Enhancements"
   - "Type: Bug": "Bug Fixes"
 
-merge_actions:
- - built_in:bump_version:
-    ignore_labels:
-     - "Version: Skip Bump"
-     - "Expeditor: Skip All"
- - bash:.expeditor/update_version.sh:
-    only_if: built_in:bump_version
- - built_in:update_changelog:
-    ignore_labels:
-     - "Changelog: Skip Update"
-     - "Expeditor: Skip All"
+subscriptions:
+  - workload: pull_request_merged:{{github_repo}}:{{release_branch}}:*
+    actions:
+      - built_in:bump_version:
+         ignore_labels:
+           - "Version: Skip Bump"
+           - "Expeditor: Skip All"
+      - bash:.expeditor/update_version.sh:
+         only_if: built_in:bump_version
+      - built_in:update_changelog:
+         ignore_labels:
+          - "Changelog: Skip Update"
+          - "Expeditor: Skip All"
 


### PR DESCRIPTION
Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

### Description

i) The merge_actions subscription shortcut has been deprecated. All subscriptions should be declared via the subscriptions block for clarity.
ii) Release branches are a first-class concept in Expeditor, and should be represented as such.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
