### PR TITLE
Replace deprecated --without flag with bundle config

### DIFF
--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -8,7 +8,8 @@ ruby -v
 bundle --version
 
 echo "--- bundle install"
-bundle install --jobs=7 --retry=3 --without tools maintenance deploy
+bundle config set --local without tools maintenance deploy
+bundle install --jobs=7 --retry=3
 bundle update
 
 echo "+++ bundle exec rake lint"


### PR DESCRIPTION
Replacing **--without** flag with **bundle config** to get rid of bundler deprecated warning :

[DEPRECATED] The --without flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use bundle config set without 'development doc', and stop using this flag

Signed-off-by: jayashri garud <jgarud@msystechnologies.com>

### Description

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec](https://github.com/inspec/inspec-azure/CONTRIBUTING.MD) document before submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
