### PR TITLE
Fix YAML frontmatter lines in resource docs pages

### DIFF
--- a/docs/resources/azure_ddos_protection_resource.md
+++ b/docs/resources/azure_ddos_protection_resource.md
@@ -1,7 +1,7 @@
 ---
 title: About the azure_ddos_protection_resource Resource
 platform: azure
- ---
+---
 
 # azure_ddos_protection_resource
 

--- a/docs/resources/azure_ddos_protection_resources.md
+++ b/docs/resources/azure_ddos_protection_resources.md
@@ -1,7 +1,7 @@
 ---
 title: About the azure_ddos_protection_resources Resource
 platform: azure
- ---
+---
 
 # azure_ddos_protection_resources
 

--- a/docs/resources/azure_dns_zones_resource.md
+++ b/docs/resources/azure_dns_zones_resource.md
@@ -1,7 +1,7 @@
 ---
 title: About the azure_dns_zones_resource Resource
 platform: azure
-  ---
+---
 
 # azure_dns_zones_resource
 

--- a/docs/resources/azure_dns_zones_resources.md
+++ b/docs/resources/azure_dns_zones_resources.md
@@ -1,7 +1,7 @@
 ---
 title: About the azure_dns_zones_resources Resource
 platform: azure
-  ---
+---
 
 # azure_dns_zones_resources
 

--- a/docs/resources/azure_policy_assignments.md
+++ b/docs/resources/azure_policy_assignments.md
@@ -3,7 +3,7 @@ title: About the azure_policy_assignments Resource
 platform: azure
 ---
 
-## azure_policy_assignments
+# azure_policy_assignments
 
 Use the `azure_policy_assignments` InSpec resource to examine assignments of Azure policy to resources and resource groups.
 

--- a/docs/resources/azure_virtual_wan.md
+++ b/docs/resources/azure_virtual_wan.md
@@ -3,7 +3,7 @@ title: About the azure_virtual_wan Resource
 platform: azure
 ---
 
-## azure_virtual_wan
+# azure_virtual_wan
 
 Use the `azure_virtual_wan` InSpec audit resource to test the properties related to a Azure Virtual WAN in a given resource group.
 


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <Ian.Maddaus@progress.com>

### Description

Fix the YAML frontmatter lines in four docs pages.
Fix page title heading in two pages.

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec](https://github.com/inspec/inspec-azure/CONTRIBUTING.MD) document before submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
