### PR TITLE
Removed broken type conversion in NSG resource

### DIFF
--- a/libraries/azure_network_security_group.rb
+++ b/libraries/azure_network_security_group.rb
@@ -170,10 +170,9 @@ class AzureNetworkSecurityGroup < AzureGenericResource
   end
 
   def destination_port_ranges(properties)
-    properties_hash = properties.to_h
-    return Array(properties.destinationPortRange) unless properties_hash.include?(:destinationPortRanges)
+    return Array(properties.destinationPortRange) unless properties.include?(:destinationPortRanges)
 
-    return properties.destinationPortRanges unless properties_hash.include?(:destinationPortRange)
+    return properties.destinationPortRanges unless properties.include?(:destinationPortRange)
 
     properties.destinationPortRanges + Array(properties.destinationPortRange)
   end


### PR DESCRIPTION
Signed-off-by: Joe McCrea <joe.mccrea@sap.com>

### Description

We discovered an issue when scanning certain Network Security Groups.

Within the 'destination_port_ranges' function, which takes 'properties' as an argument, a type conversion is done on 'properties' to convert it to a hash. This does not work and causes a nil value to be assigned to the new 'properties_hash' variable.

Any time this is then used it does not return the expected value, meaning that the proper checks are not carried out in order to return the correct value for the destination port ranges. The only reason this is not very visible or obvious is due to the values returned from the Azure API, as when 'destinationPortRanges' is returned, 'destinationPortRange' is not returned at all in the response. However when 'destinationPortRange' is returned, an empty value is returned for 'destinationPortRanges' here, which makes it look like the checks have worked even though they have not.

### Issues Resolved

Bug in specific situations when the Network Security Group resource is used.

### Check List

- [ ] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
