### PR TITLE
Add code to run SonarScanner on test unit runs

### DIFF
--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -19,7 +19,7 @@ bundle exec rake test:unit
 RAKE_EXIT=$?
 
 # If coverage is enabled, then we need to pick up the coverage/coverage.json file
-if [ -n "$CI_ENABLE_COVERAGE" ]; then
+if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
   echo "--- installing sonarscanner"
   export SONAR_SCANNER_VERSION=4.6.2.2472
   export SONAR_SCANNER_HOME=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux
@@ -27,6 +27,9 @@ if [ -n "$CI_ENABLE_COVERAGE" ]; then
   unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
   export PATH=$SONAR_SCANNER_HOME/bin:$PATH
   export SONAR_SCANNER_OPTS="-server"
+
+  echo "--- fetching Sonar token"
+  export SONAR_TOKEN=$(vault kv get -field token secrets/cubbyhole/inspec-sonar-token)
 
   echo "--- running sonarscanner"
   sonar-scanner \

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -28,8 +28,14 @@ if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
   export PATH=$SONAR_SCANNER_HOME/bin:$PATH
   export SONAR_SCANNER_OPTS="-server"
 
+  echo "--- installing vault"
+  export VAULT_VERSION=1.9.3
+  export VAULT_HOME=$HOME/vault
+  curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/vault/$VAULT_VERSION/vault_${VAULT_VERSION}_linux_amd64.zip
+  unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
+
   echo "--- fetching Sonar token"
-  export SONAR_TOKEN=$(vault kv get -field token secrets/cubbyhole/inspec-sonar-token)
+  export SONAR_TOKEN=$($VAULT_HOME/vault kv get -field token secrets/cubbyhole/inspec-sonar-token)
 
   echo "--- running sonarscanner"
   sonar-scanner \

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -28,14 +28,14 @@ if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
   export PATH=$SONAR_SCANNER_HOME/bin:$PATH
   export SONAR_SCANNER_OPTS="-server"
 
-  echo "--- installing vault"
-  export VAULT_VERSION=1.9.3
-  export VAULT_HOME=$HOME/vault
-  curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/vault/$VAULT_VERSION/vault_${VAULT_VERSION}_linux_amd64.zip
-  unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
+  # echo "--- installing vault"
+  # export VAULT_VERSION=1.9.3
+  # export VAULT_HOME=$HOME/vault
+  # curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/vault/$VAULT_VERSION/vault_${VAULT_VERSION}_linux_amd64.zip
+  # unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
 
-  echo "--- fetching Sonar token"
-  export SONAR_TOKEN=$($VAULT_HOME/vault kv get -field token secrets/cubbyhole/inspec-sonar-token)
+  # echo "--- fetching Sonar token"
+  # export SONAR_TOKEN=$($VAULT_HOME/vault kv get -field token secrets/cubbyhole/inspec-sonar-token)
 
   echo "--- running sonarscanner"
   sonar-scanner \

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -28,14 +28,14 @@ if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
   export PATH=$SONAR_SCANNER_HOME/bin:$PATH
   export SONAR_SCANNER_OPTS="-server"
 
-  # echo "--- installing vault"
-  # export VAULT_VERSION=1.9.3
-  # export VAULT_HOME=$HOME/vault
-  # curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/vault/$VAULT_VERSION/vault_${VAULT_VERSION}_linux_amd64.zip
-  # unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
+  echo "--- installing vault"
+  export VAULT_VERSION=1.9.3
+  export VAULT_HOME=$HOME/vault
+  curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/vault/$VAULT_VERSION/vault_${VAULT_VERSION}_linux_amd64.zip
+  unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
 
-  # echo "--- fetching Sonar token"
-  # export SONAR_TOKEN=$($VAULT_HOME/vault kv get -field token secrets/cubbyhole/inspec-sonar-token)
+  echo "--- fetching Sonar token"
+  export SONAR_TOKEN=$($VAULT_HOME/vault kv get -field token secrets/cubbyhole/inspec-sonar-token)
 
   echo "--- running sonarscanner"
   sonar-scanner \

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -16,3 +16,24 @@ bundle exec rake lint
 
 echo "+++ bundle exec rake test:unit"
 bundle exec rake test:unit
+RAKE_EXIT=$?
+
+# If coverage is enabled, then we need to pick up the coverage/coverage.json file
+if [ -n "$CI_ENABLE_COVERAGE" ]; then
+  echo "--- installing sonarscanner"
+  export SONAR_SCANNER_VERSION=4.6.2.2472
+  export SONAR_SCANNER_HOME=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-linux
+  curl --create-dirs -sSLo $HOME/.sonar/sonar-scanner.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
+  unzip -o $HOME/.sonar/sonar-scanner.zip -d $HOME/.sonar/
+  export PATH=$SONAR_SCANNER_HOME/bin:$PATH
+  export SONAR_SCANNER_OPTS="-server"
+
+  echo "--- running sonarscanner"
+  sonar-scanner \
+  -Dsonar.organization=inspec \
+  -Dsonar.projectKey=inspec_inspec-azure \
+  -Dsonar.sources=. \
+  -Dsonar.host.url=https://sonarcloud.io
+fi
+
+exit $RAKE_EXIT

--- a/.expeditor/buildkite/verify.sh
+++ b/.expeditor/buildkite/verify.sh
@@ -34,7 +34,7 @@ if [ -n "${CI_ENABLE_COVERAGE:-}" ]; then
   curl --create-dirs -sSLo $VAULT_HOME/vault.zip https://releases.hashicorp.com/vault/$VAULT_VERSION/vault_${VAULT_VERSION}_linux_amd64.zip
   unzip -o $VAULT_HOME/vault.zip -d $VAULT_HOME
 
-  echo "--- fetching Sonar token"
+  echo "--- fetching Sonar token from vault"
   export SONAR_TOKEN=$($VAULT_HOME/vault kv get -field token secrets/cubbyhole/inspec-sonar-token)
 
   echo "--- running sonarscanner"

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -9,7 +9,6 @@ slack:
 pipelines:
  - verify:
     description: Pull Request validation tests
-    public: true
 
 github:
  delete_branch_on_merge: true

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -9,6 +9,7 @@ slack:
 pipelines:
  - verify:
     description: Pull Request validation tests
+    public: false
 
 github:
  delete_branch_on_merge: true

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -9,7 +9,6 @@ slack:
 pipelines:
  - verify:
     description: Pull Request validation tests
-    public: true
 
 github:
  delete_branch_on_merge: true
@@ -19,7 +18,7 @@ github:
 
 release_branches:
   - main
- 
+
 changelog:
  categories:
   - "Type: New Resource": "New Resources"

--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -9,7 +9,7 @@ slack:
 pipelines:
  - verify:
     description: Pull Request validation tests
-    public: false
+    public: true
 
 github:
  delete_branch_on_merge: true

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -2,7 +2,7 @@
 expeditor:
   defaults:
     buildkite:
-      timeout_in_minutes: 15
+      timeout_in_minutes: 20
 
 steps:
 
@@ -18,6 +18,7 @@ steps:
   command:
     - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
   expeditor:
+    secrets: true
     executor:
       docker:
         image: ruby:2.7-buster

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -18,10 +18,7 @@ steps:
   command:
     - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
   expeditor:
-    secrets:
-      SONAR_TOKEN:
-        path: secrets/cubbyhole/inspec-sonar-token
-        field: token
+    secrets: true
     executor:
       docker:
         image: ruby:2.7-buster

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -18,7 +18,10 @@ steps:
   command:
     - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
   expeditor:
-    secrets: true
+    secrets:
+      SONAR_TOKEN:
+        path: secrets/cubbyhole/inspec-sonar-token
+        field: token
     executor:
       docker:
         image: ruby:2.7-buster

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.ruby.coverage.reportPaths=coverage/coverage.json


### PR DESCRIPTION
### Description

Modifies verify.sh to download sonarscanner and run it on test unit runs where the CI_ENABLE_COVERAGE flag is set. This will also upload the coverage/coverage.json file to sonarcloud.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
