### PR TITLE
Resource-202 update azure tests to use ruby versions 2.7 and 3.0 only 

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -26,6 +26,7 @@ steps:
   command:
     - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
   expeditor:
+    secrets: true
     executor:
       docker:
         image: ruby:3.0

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -20,7 +20,7 @@ steps:
   expeditor:
     executor:
       docker:
-        image: ruby:2.7
+        image: ruby:2.7-buster
 
 - label: run-tests-ruby-3.0
   command:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -16,7 +16,7 @@ steps:
 
 - label: run-tests-ruby-2.7
   command:
-    - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
+    - /workdir/.expeditor/buildkite/verify.sh
   expeditor:
     executor:
       docker:

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -6,19 +6,26 @@ expeditor:
 
 steps:
 
-- label: run-tests-ruby-2.6
+- label: lint-ruby-3.0
   command:
-    - /workdir/.expeditor/buildkite/verify.sh
+    - RAKE_TASK=lint /workdir/.expeditor/buildkite/verify.sh
   expeditor:
     executor:
       docker:
-        image: ruby:2.6-stretch
+        image: ruby:3.0
 
 - label: run-tests-ruby-2.7
   command:
-    - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
+    - RAKE_TASK=default /workdir/.expeditor/buildkite/verify.sh
   expeditor:
-    secrets: true
     executor:
       docker:
-        image: ruby:2.7-buster
+        image: ruby:2.7
+
+- label: run-tests-ruby-3.0
+  command:
+    - RAKE_TASK=default /workdir/.expeditor/buildkite/verify.sh
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.0

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -16,7 +16,7 @@ steps:
 
 - label: run-tests-ruby-2.7
   command:
-    - RAKE_TASK=default /workdir/.expeditor/buildkite/verify.sh
+    - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
   expeditor:
     executor:
       docker:
@@ -24,7 +24,7 @@ steps:
 
 - label: run-tests-ruby-3.0
   command:
-    - RAKE_TASK=default /workdir/.expeditor/buildkite/verify.sh
+    - CI_ENABLE_COVERAGE=1 /workdir/.expeditor/buildkite/verify.sh
   expeditor:
     executor:
       docker:

--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,6 @@ gem 'faraday_middleware'
 gem 'inspec-bin'
 gem 'rake'
 
-if Gem.ruby_version < Gem::Version.new('2.7.0')
-  gem 'activesupport', '< 7.0.0'
-end
-
 group :development do
   gem 'pry'
   gem 'pry-byebug'


### PR DESCRIPTION
Removes Ruby 2.6 (EOL) from CI testing.

Moves linting to Ruby 3.0.