### PR TITLE
Remove hugo and go versions from netlify config

### DIFF
--- a/docs-chef-io/netlify.toml
+++ b/docs-chef-io/netlify.toml
@@ -1,9 +1,7 @@
 [build]
 
 [build.environment]
-  HUGO_VERSION = "0.91.2"
   HUGO_ENABLEGITINFO = "true"
-  GO_VERSION = "1.15"
   NODE_ENV = "development"
 
 [build.processing]


### PR DESCRIPTION
Signed-off-by: Ian Maddaus <ian.maddaus@progress.com>

### Description

Remove Hugo and Go version from Netlify config. The current specified version of Hugo has a bug in it that's making builds fail, and it's easier to specify these things in the Netlify Web UI.

Please describe what this change achieves. Ensure you have read the [Contributing to InSpec](https://github.com/inspec/inspec-azure/CONTRIBUTING.MD) document before submitting.

### Issues Resolved

List any existing issues this PR resolves, or any Discourse or StackOverflow discussion that's relevant

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] `rake lint` passes
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
