### PR TITLE
Handle unpack uri creds

### DIFF
--- a/libraries/backend/azure_connection.rb
+++ b/libraries/backend/azure_connection.rb
@@ -253,7 +253,9 @@ class AzureConnection
       Inspec::Config.mock.unpack_train_credentials
     else
       config = Inspec::Config.cached
-      return {} unless config.present? # existing external platforms might not be aware of above environment variable
+      # existing external platforms might not be aware of above environment variable
+      # some backends don't respond to unpack_train_credentials method
+      return {} unless config.respond_to?(:unpack_train_credentials)
 
       config.unpack_train_credentials
     end

--- a/libraries/backend/azure_connection.rb
+++ b/libraries/backend/azure_connection.rb
@@ -249,15 +249,21 @@ class AzureConnection
   private
 
   def creds_from_uri
-    if ENV["RAKE_ENV"] == "test"
+    return @creds_from_uri if defined? @creds_from_uri
+
+    if ENV['RAKE_ENV'] == 'test'
       Inspec::Config.mock.unpack_train_credentials
     else
-      config = Inspec::Config.cached
-      # existing external platforms might not be aware of above environment variable
-      # some backends don't respond to unpack_train_credentials method
-      return {} unless config.respond_to?(:unpack_train_credentials)
+      begin
+        config = Inspec::Config.cached
+        # existing external platforms might not be aware of above environment variable
+        # some backends don't respond to unpack_train_credentials method
+        return {} unless config.respond_to?(:unpack_train_credentials)
 
-      config.unpack_train_credentials
+        config.unpack_train_credentials
+      rescue StandardError => e
+        {}
+      end
     end
   end
 end

--- a/libraries/backend/azure_connection.rb
+++ b/libraries/backend/azure_connection.rb
@@ -251,7 +251,7 @@ class AzureConnection
   def creds_from_uri
     return @creds_from_uri if defined? @creds_from_uri
 
-    if ENV['RAKE_ENV'] == 'test'
+    if ENV["RAKE_ENV"] == "test"
       Inspec::Config.mock.unpack_train_credentials
     else
       begin
@@ -261,7 +261,7 @@ class AzureConnection
         return {} unless config.respond_to?(:unpack_train_credentials)
 
         config.unpack_train_credentials
-      rescue StandardError => e
+      rescue StandardError => _e
         {}
       end
     end


### PR DESCRIPTION
### Description

calling unpack_train_credentials on config cache object results in `Can't find train plugin Inspec::Backend::Class. Please install it first. (Train::PluginLoadError)` in test environments. Hence handle unpacking of URI creds.
```
cd /workdir && bundle exec inspec vendor src/inspec/supported/cis-azure-foundations-level1-v1.5.0 --overwrite
  | Dependencies for profile src/inspec/supported/cis-azure-foundations-level1-v1.5.0 successfully vendored to /workdir/src/inspec/supported/cis-azure-foundations-level1-v1.5.0/vendor
  | cd /workdir && bundle exec inspec check src/inspec/supported/cis-azure-foundations-level1-v1.5.0
  | Top level ::CompositeIO is deprecated, require 'multipart/post' and use `Multipart::Post::CompositeReadIO` instead!
  | Top level ::Parts is deprecated, require 'multipart/post' and use `Multipart::Post::Parts` instead!
  | libraries/azure_network_security_group.rb:169: warning: already initialized constant #<Class:0x000055e135ff98f0>::AzureNetworkSecurityGroup::SPECIFIC_CRITERIA
  | libraries/azure_network_security_group.rb:161: warning: previous definition of SPECIFIC_CRITERIA was here
  | bundler: failed to load command: inspec (/workdir/vendor/bundle/ruby/2.7.0/bin/inspec)
  | Traceback (most recent call last):
  | 50: from /opt/asdf/installs/ruby/2.7.2/bin/bundle:23:in `<main>'
  | 49: from /opt/asdf/installs/ruby/2.7.2/bin/bundle:23:in `load'
  | 48: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/exe/bundle:36:in `<top (required)>'
  | 47: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
  | 46: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/exe/bundle:48:in `block in <top (required)>'
  | 45: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli.rb:25:in `start'
  | 44: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
  | 43: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli.rb:31:in `dispatch'
  | 42: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  | 41: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  | 40: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  | 39: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli.rb:483:in `exec'
  | 38: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli/exec.rb:23:in `run'
  | 37: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli/exec.rb:58:in `kernel_load'
  | 36: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli/exec.rb:58:in `load'
  | 35: from /workdir/vendor/bundle/ruby/2.7.0/bin/inspec:23:in `<top (required)>'
  | 34: from /workdir/vendor/bundle/ruby/2.7.0/bin/inspec:23:in `load'
  | 33: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-bin-4.56.20/bin/inspec:11:in `<top (required)>'
  | 32: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/base_cli.rb:35:in `start'
  | 31: from /workdir/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
  | 30: from /workdir/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
  | 29: from /workdir/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
  | 28: from /workdir/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
  | 27: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/cli.rb:114:in `check'
  | 26: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:574:in `check'
  | 25: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:612:in `controls_count'
  | 24: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:212:in `params'
  | 23: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:773:in `load_params'
  | 22: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:780:in `load_checks_params'
  | 21: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:224:in `collect_tests'
  | 20: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:224:in `each'
  | 19: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:229:in `block in collect_tests'
  | 18: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile_context.rb:155:in `load_control_file'
  | 17: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile_context.rb:171:in `load_with_context'
  | 16: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile_context.rb:171:in `instance_eval'
  | 15: from src/inspec/supported/cis-azure-foundations-level1-v1.5.0/controls/translated-controls.rb:3:in `load_with_context'
  | 14: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile_context.rb:256:in `block (2 levels) in add_registry_methods'
  | 13: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile_context.rb:256:in `new'
  | 12: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/resource.rb:119:in `initialize'
  | 11: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/resource.rb:54:in `supersuper_initialize'
  | 10: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/resource.rb:121:in `block in initialize'
  | 9: from libraries/azure_microsoft_defender_security_contact.rb:23:in `initialize'
  | 8: from libraries/azure_generic_resource.rb:17:in `initialize'
  | 7: from libraries/azure_backend.rb:58:in `initialize'
  | 6: from libraries/backend/azure_connection.rb:78:in `credentials'
  | 5: from libraries/backend/azure_connection.rb:258:in `creds_from_uri'
  | 4: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/config.rb:121:in `unpack_train_credentials'
  | 3: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/config.rb:159:in `_utc_merge_transport_options'
  | 2: from /workdir/vendor/bundle/ruby/2.7.0/gems/train-core-3.10.7/lib/train.rb:28:in `options'
  | 1: from /workdir/vendor/bundle/ruby/2.7.0/gems/train-core-3.10.7/lib/train.rb:44:in `load_transport'
  | /workdir/vendor/bundle/ruby/2.7.0/gems/train-core-3.10.7/lib/train.rb:44:in `require': cannot load such file -- train/transports/Inspec::Backend::Class (LoadError)
  | 50: from /opt/asdf/installs/ruby/2.7.2/bin/bundle:23:in `<main>'
  | 49: from /opt/asdf/installs/ruby/2.7.2/bin/bundle:23:in `load'
  | 48: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/exe/bundle:36:in `<top (required)>'
  | 47: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
  | 46: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/exe/bundle:48:in `block in <top (required)>'
  | 45: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli.rb:25:in `start'
  | 44: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
  | 43: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli.rb:31:in `dispatch'
  | 42: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  | 41: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  | 40: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  | 39: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli.rb:483:in `exec'
  | 38: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli/exec.rb:23:in `run'
  | 37: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli/exec.rb:58:in `kernel_load'
  | 36: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli/exec.rb:58:in `load'
  | 35: from /workdir/vendor/bundle/ruby/2.7.0/bin/inspec:23:in `<top (required)>'
  | 34: from /workdir/vendor/bundle/ruby/2.7.0/bin/inspec:23:in `load'
  | 33: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-bin-4.56.20/bin/inspec:11:in `<top (required)>'
  | 32: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/base_cli.rb:35:in `start'
  | 31: from /workdir/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
  | 30: from /workdir/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
  | 29: from /workdir/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
  | 28: from /workdir/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
  | 27: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/cli.rb:114:in `check'
  | 26: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:574:in `check'
  | 25: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:612:in `controls_count'
  | 24: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:212:in `params'
  | 23: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:773:in `load_params'
  | 22: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:780:in `load_checks_params'
  | 21: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:224:in `collect_tests'
  | 20: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:224:in `each'
  | 19: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:229:in `block in collect_tests'
  | 18: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile_context.rb:155:in `load_control_file'
  | 17: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile_context.rb:171:in `load_with_context'
  | 16: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile_context.rb:171:in `instance_eval'
  | 15: from src/inspec/supported/cis-azure-foundations-level1-v1.5.0/controls/translated-controls.rb:3:in `load_with_context'
  | 14: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile_context.rb:256:in `block (2 levels) in add_registry_methods'
  | 13: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile_context.rb:256:in `new'
  | 12: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/resource.rb:119:in `initialize'
  | 11: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/resource.rb:54:in `supersuper_initialize'
  | 10: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/resource.rb:121:in `block in initialize'
  | 9: from libraries/azure_microsoft_defender_security_contact.rb:23:in `initialize'
  | 8: from libraries/azure_generic_resource.rb:17:in `initialize'
  | 7: from libraries/azure_backend.rb:58:in `initialize'
  | 6: from libraries/backend/azure_connection.rb:78:in `credentials'
  | 5: from libraries/backend/azure_connection.rb:258:in `creds_from_uri'
  | 4: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/config.rb:121:in `unpack_train_credentials'
  | 3: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/config.rb:159:in `_utc_merge_transport_options'
  | 2: from /workdir/vendor/bundle/ruby/2.7.0/gems/train-core-3.10.7/lib/train.rb:28:in `options'
  | 1: from /workdir/vendor/bundle/ruby/2.7.0/gems/train-core-3.10.7/lib/train.rb:38:in `load_transport'
  | /workdir/vendor/bundle/ruby/2.7.0/gems/train-core-3.10.7/lib/train.rb:60:in `rescue in load_transport': Can't find train plugin Inspec::Backend::Class. Please install it first. (Train::PluginLoadError)
  | 32: from /opt/asdf/installs/ruby/2.7.2/bin/bundle:23:in `<main>'
  | 31: from /opt/asdf/installs/ruby/2.7.2/bin/bundle:23:in `load'
  | 30: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/exe/bundle:36:in `<top (required)>'
  | 29: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/friendly_errors.rb:120:in `with_friendly_errors'
  | 28: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/exe/bundle:48:in `block in <top (required)>'
  | 27: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli.rb:25:in `start'
  | 26: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
  | 25: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli.rb:31:in `dispatch'
  | 24: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
  | 23: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
  | 22: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
  | 21: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli.rb:483:in `exec'
  | 20: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli/exec.rb:23:in `run'
  | 19: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli/exec.rb:58:in `kernel_load'
  | 18: from /opt/asdf/installs/ruby/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.3.18/lib/bundler/cli/exec.rb:58:in `load'
  | 17: from /workdir/vendor/bundle/ruby/2.7.0/bin/inspec:23:in `<top (required)>'
  | 16: from /workdir/vendor/bundle/ruby/2.7.0/bin/inspec:23:in `load'
  | 15: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-bin-4.56.20/bin/inspec:11:in `<top (required)>'
  | 14: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/base_cli.rb:35:in `start'
  | 13: from /workdir/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
  | 12: from /workdir/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
  | 11: from /workdir/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
  | 10: from /workdir/vendor/bundle/ruby/2.7.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
  | 9: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/cli.rb:114:in `check'
  | 8: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:574:in `check'
  | 7: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:612:in `controls_count'
  | 6: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:212:in `params'
  | 5: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:773:in `load_params'
  | 4: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:780:in `load_checks_params'
  | 3: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:224:in `collect_tests'
  | 2: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:224:in `each'
  | 1: from /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:228:in `block in collect_tests'
  | /workdir/vendor/bundle/ruby/2.7.0/gems/inspec-core-4.56.20/lib/inspec/profile.rb:232:in `rescue in block in collect_tests': Failed to load source for controls/translated-controls.rb: Can't find train plugin Inspec::Backend::Class. Please install it first. (Inspec::Exceptions::ProfileLoadFailed)

<br class="Apple-interchange-newline">
```
### Issues Resolved

catch mentioned exception and rescue errors with empty Hash


### Check List

- [ ] New functionality includes tests
- [X] All tests pass
- [X] `rake lint` passes
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
