### PR TITLE
Create the integration test for datafactory linked_services and pipeline_run_resource

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -510,6 +510,10 @@ output "sample_directory_object" {
   value = var.sample_directory_object
 }
 
+output "linked_service_id" {
+  value = azurerm_data_factory_linked_service_mysql.dflsmsql.id
+}
+
 output "linked_service_name" {
   value = azurerm_data_factory_linked_service_mysql.dflsmsql.name
 }

--- a/test/integration/verify/controls/azure_data_factory_linked_services.rb
+++ b/test/integration/verify/controls/azure_data_factory_linked_services.rb
@@ -1,0 +1,24 @@
+resource_group = input("resource_group", value: "", description: "")
+factory_name = input("df_name", value: "", description: "")
+linked_service_name = input("linked_service_name", value: "", description: "")
+linked_service_id = input("linked_service_id", value: "", description: "")
+
+control "azure_data_factory_linked_services" do
+  title "Testing the plural resource of azure_data_factory_linked_services."
+  desc "Testing the plural resource of azure_data_factory_linked_services."
+  
+  describe azure_data_factory_linked_services(resource_group: resource_group, factory_name: factory_name) do
+    it { should exist }
+  end
+  
+  describe azure_data_factory_linked_services(resource_group: resource_group, factory_name: factory_name) do
+    its("names") { should include linked_service_name }
+    its("types") { should include "Microsoft.DataFactory/factories/linkedservices" }
+    its("ids") { should include linked_service_id }
+    its("properties") { should_not be_empty }
+  end
+  
+  describe azure_data_factory_linked_services(resource_group: resource_group, factory_name: "not-there") do
+    it { should_not exist }
+  end
+end

--- a/test/integration/verify/controls/azure_data_factory_linked_services.rb
+++ b/test/integration/verify/controls/azure_data_factory_linked_services.rb
@@ -6,18 +6,18 @@ linked_service_id = input("linked_service_id", value: "", description: "")
 control "azure_data_factory_linked_services" do
   title "Testing the plural resource of azure_data_factory_linked_services."
   desc "Testing the plural resource of azure_data_factory_linked_services."
-  
+
   describe azure_data_factory_linked_services(resource_group: resource_group, factory_name: factory_name) do
     it { should exist }
   end
-  
+
   describe azure_data_factory_linked_services(resource_group: resource_group, factory_name: factory_name) do
     its("names") { should include linked_service_name }
     its("types") { should include "Microsoft.DataFactory/factories/linkedservices" }
     its("ids") { should include linked_service_id }
     its("properties") { should_not be_empty }
   end
-  
+
   describe azure_data_factory_linked_services(resource_group: resource_group, factory_name: "not-there") do
     it { should_not exist }
   end

--- a/test/integration/verify/controls/azure_data_factory_pipeline_run_resource.rb
+++ b/test/integration/verify/controls/azure_data_factory_pipeline_run_resource.rb
@@ -1,0 +1,14 @@
+# We dont have a terraform to check this resource. So this control should be checked manually.
+
+skip_control "azure_data_factory_pipeline_run_resource" do
+  title "Testing the singular resource of azure_data_factory_pipeline_run_resource."
+  desc "Testing the singular resource of azure_data_factory_pipeline_run_resource."
+
+  describe azure_data_factory_pipeline_run_resource(resource_group: 'test', factory_name: 'test', run_id: '0448d45a-a0bd-23f3-90a5-bfeea9264aed') do
+    it { should exist }
+  end
+
+  describe azure_data_factory_pipeline_run_resource(resource_group: 'not-there', factory_name: 'not-there', run_id: 'not-there') do
+    it { should_not exist }
+  end
+end

--- a/test/integration/verify/controls/azure_data_factory_pipeline_run_resource.rb
+++ b/test/integration/verify/controls/azure_data_factory_pipeline_run_resource.rb
@@ -4,11 +4,11 @@ skip_control "azure_data_factory_pipeline_run_resource" do
   title "Testing the singular resource of azure_data_factory_pipeline_run_resource."
   desc "Testing the singular resource of azure_data_factory_pipeline_run_resource."
 
-  describe azure_data_factory_pipeline_run_resource(resource_group: 'test', factory_name: 'test', run_id: '0448d45a-a0bd-23f3-90a5-bfeea9264aed') do
+  describe azure_data_factory_pipeline_run_resource(resource_group: "test", factory_name: "test", run_id: "0448d45a-a0bd-23f3-90a5-bfeea9264aed") do
     it { should exist }
   end
 
-  describe azure_data_factory_pipeline_run_resource(resource_group: 'not-there', factory_name: 'not-there', run_id: 'not-there') do
+  describe azure_data_factory_pipeline_run_resource(resource_group: "not-there", factory_name: "not-there", run_id: "not-there") do
     it { should_not exist }
   end
 end

--- a/test/integration/verify/controls/azure_data_factory_pipeline_run_resources.rb
+++ b/test/integration/verify/controls/azure_data_factory_pipeline_run_resources.rb
@@ -1,0 +1,14 @@
+# We dont have a terraform to check this resource. So this control should be checked manually.
+
+skip_control "azure_data_factory_pipeline_run_resources" do
+  title "Testing the plural resource of azure_data_factory_pipeline_run_resources."
+  desc "Testing the plural resource of azure_data_factory_pipeline_run_resources."
+
+  describe azure_data_factory_pipeline_run_resources(resource_group: 'test', factory_name: 'test') do
+    it { should exist }
+  end
+
+  describe azure_data_factory_pipeline_run_resources(resource_group: 'not-there', factory_name: 'not-there') do
+    it { should_not exist }
+  end
+end

--- a/test/integration/verify/controls/azure_data_factory_pipeline_run_resources.rb
+++ b/test/integration/verify/controls/azure_data_factory_pipeline_run_resources.rb
@@ -4,11 +4,11 @@ skip_control "azure_data_factory_pipeline_run_resources" do
   title "Testing the plural resource of azure_data_factory_pipeline_run_resources."
   desc "Testing the plural resource of azure_data_factory_pipeline_run_resources."
 
-  describe azure_data_factory_pipeline_run_resources(resource_group: 'test', factory_name: 'test') do
+  describe azure_data_factory_pipeline_run_resources(resource_group: "test", factory_name: "test") do
     it { should exist }
   end
 
-  describe azure_data_factory_pipeline_run_resources(resource_group: 'not-there', factory_name: 'not-there') do
+  describe azure_data_factory_pipeline_run_resources(resource_group: "not-there", factory_name: "not-there") do
     it { should_not exist }
   end
 end


### PR DESCRIPTION
### Description

1. Created the Integration test for azure_data_factory_linked_services [only plural resource test]
2. Created the Integration test for azure_data_factory_pipeline_run_resource [Both singular & plural resource tests]
3. Added the required terraform.

### Issues Resolved

NA

### Check List

- [x] New functionality includes tests
- [x] All tests pass
- [x] `rake lint` passes
- [x] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
